### PR TITLE
Update settings.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -109,7 +109,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 #PREBID_BIDDER_CODE = ["pubmatic"]
 #
 # Prebid line item generator only accepts a single value
-PREBID_BIDDER_CODE = None
+#PREBID_BIDDER_CODE = None
 
 # Price buckets. This should match your Prebid settings for the partner. See:
 # http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity

--- a/settings.py
+++ b/settings.py
@@ -106,10 +106,10 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 
 # OpenWrap: you can specify an array to target multiple bidders with one line item
 # not applicable for JWPLAYER, IN_APP
-PREBID_BIDDER_CODE = ["pubmatic"]
+#PREBID_BIDDER_CODE = ["pubmatic"]
 #
 # Prebid line item generator only accepts a single value
-#PREBID_BIDDER_CODE = None
+PREBID_BIDDER_CODE = None
 
 # Price buckets. This should match your Prebid settings for the partner. See:
 # http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity


### PR DESCRIPTION
Setting PREBID_BIDDER_CODE to 'None' as default should be lines for all bidders instead of just PubMatic