### PR TITLE
Update add_new_openwrap_partner.py

### DIFF
--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -628,10 +628,8 @@ def get_creative_config(creative_type, bidder_str, order_name, advertiser_id, si
         creative_configs = dfp.create_creatives.create_creative_configs_for_video(advertiser_id, sizes, prefix, constant.JWP_VAST_URL, constant.JWP_DURATION)
     else:
         use_safe_frame = False
-        if creative_type == constant.AMP:
-            use_safe_frame = True
-        if creative_type == constant.WEB_SAFEFRAME:
-            use_safe_frame = True
+        if creative_type in (constant.WEB_SAFEFRAME, constant.AMP):
+        use_safe_frame = True
         creative_file = get_creative_file(creative_type)
         creative_configs = dfp.create_creatives.create_duplicate_creative_configs(
           bidder_str, order_name, advertiser_id, sizes, num_creatives, creative_file=creative_file, safe_frame=use_safe_frame, prefix=prefix)

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -629,7 +629,7 @@ def get_creative_config(creative_type, bidder_str, order_name, advertiser_id, si
     else:
         use_safe_frame = False
         if creative_type in (constant.WEB_SAFEFRAME, constant.AMP):
-        use_safe_frame = True
+          use_safe_frame = True
         creative_file = get_creative_file(creative_type)
         creative_configs = dfp.create_creatives.create_duplicate_creative_configs(
           bidder_str, order_name, advertiser_id, sizes, num_creatives, creative_file=creative_file, safe_frame=use_safe_frame, prefix=prefix)

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -628,6 +628,8 @@ def get_creative_config(creative_type, bidder_str, order_name, advertiser_id, si
         creative_configs = dfp.create_creatives.create_creative_configs_for_video(advertiser_id, sizes, prefix, constant.JWP_VAST_URL, constant.JWP_DURATION)
     else:
         use_safe_frame = False
+        if creative_type == constant.AMP:
+            use_safe_frame = True
         if creative_type == constant.WEB_SAFEFRAME:
             use_safe_frame = True
         creative_file = get_creative_file(creative_type)


### PR DESCRIPTION
SafeFrame should always be on for AMP creatives as per: http://prebid.org/adops/setting-up-prebid-for-amp-in-dfp.html "Ensure that the Serve into a SafeFrame box is checked"