### PR TITLE
Rolling back the inapp creative. 

### DIFF
--- a/dfp/creative_snippet_openwrap_in_app.html
+++ b/dfp/creative_snippet_openwrap_in_app.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="https://media.admob.com/api/v1/google_mobile_app_ads.js"></script><script type="text/javascript">admob.events.dispatchAppEvent("pubmaticdm", "%%PATTERN:pwtsid_partnername%%");</script>
+<script type="text/javascript" src="https://media.admob.com/api/v1/google_mobile_app_ads.js"></script><script type="text/javascript">admob.events.dispatchAppEvent("pubmaticdm", "%%PATTERN:bidid%%");</script>


### PR DESCRIPTION
Rolling back the inapp creative. We may need to take seperate ticket to handle partner specific callback script for inapp..mostly required for groupm/buyerid feature in openwrapsdk