### PR TITLE
Added support to create line items for rewarded ad for OpenWrap SDK.

### DIFF
--- a/LineItem.csv
+++ b/LineItem.csv
@@ -1,2 +1,3 @@
 order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-Mobile App Header Bidding,PubMatic,1,2,1,1
+PubMatic_CSAPI_test,PubMatic,1,5,1,1
+PubMatic_CSAPI_test,PubMatic,5,10,-1,1

--- a/LineItem.csv
+++ b/LineItem.csv
@@ -1,3 +1,2 @@
 order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,1,5,1,1
-PubMatic_CSAPI_test,PubMatic,5,10,-1,1
+Mobile App Header Bidding,PubMatic,1,2,1,1

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If successful, it returns all the orders in your GAM account.
 |`DFP_TARGETED_PLACEMENT_NAMES`|The names of GAM placements targeted by the line items. Use empty array for, **Run of Network**.|array of strings|
 |`DFP_PLACEMENT_SIZES`|The creative sizes for the targeted placements.|array of objects (for example, `[{'width': '728', 'height': '90'}]`)|
 |`PREBID_BIDDER_CODE`|The value of [`pwtpid`](https://github.com/PubMatic/OpenWrap#wrapper-keys-sent-to-dfp) for this partner. Set to `None` to generate line items for all partners. Use array of strings if the line should match multiple partners.|string or array of strings|
-|`OPENWRAP_CREATIVE_TYPE`|Which type of creative to use.  Options are `WEB`, `WEB_SAFEFRAME`, `AMP`, `IN_APP`, `NATIVE`, `VIDEO`, `JWPLAYER`.|string|
+|`OPENWRAP_CREATIVE_TYPE`|Which type of creative to use.  Options are `WEB`, `WEB_SAFEFRAME`, `AMP`, `IN_APP`, `IN_APP_VIDEO`, `NATIVE`, `VIDEO`, `JWPLAYER`.|string|
 |`OPENWRAP_BUCKET_CSV`|This CSV lists buckets and price granularity; it sets `pwtecp` targeting for each line item.| string|
 |`OPENWRAP_CREATIVE_TEMPLATE` |The creative template name for Native Lineitems. This is only required when `OPENWRAP_CREATIVE_TYPE`=`NATIVE`. | string |
 
@@ -107,10 +107,10 @@ If successful, it returns all the orders in your GAM account.
 |`DFP_NUM_CREATIVES_PER_LINE_ITEM`|The number of duplicate creatives to attach to each line item. Due to GAM limitations, this should be equal to or greater than the number of ad units you serve on a given page. |int|Length of setting, `DFP_TARGETED_PLACEMENT_NAMES`|
 |`DFP_CURRENCY_CODE`|National currency to use in line items.|string|`'USD'`|
 |`DFP_SAME_ADV_EXCEPTION`|Determines whether to set the "Same Advertiser Exception" on line items. Currently works only for OpenWrap.|bool|`False`|
-|`DFP_DEVICE_CATEGORIES`|Sets device category targetting for a Line item. Valid values: `Connected TV`, `Desktop`, `Feature Phone`, `Set Top Box`, `Smartphone`, and `Tablet`. Not applicable for 'IN_APP' and 'JWPLAYER'|string or array of strings|None|
+|`DFP_DEVICE_CATEGORIES`|Sets device category targetting for a Line item. Valid values: `Connected TV`, `Desktop`, `Feature Phone`, `Set Top Box`, `Smartphone`, and `Tablet`. Not applicable for 'IN_APP', 'IN_APP_VIDEO' and 'JWPLAYER'|string or array of strings|None|
 |`DFP_ROADBLOCK_TYPE`|Same as **Display Creatives** in previous Line Item Tool version. Valid values: `ONE_OR_MORE` and `AS_MANY_AS_POSSIBLE`.|string|None|
 |`LINE_ITEM_PREFIX`|The prefix to insert before a line-item name.|string|None|
-|`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. Not applicable for 'IN_APP' and 'JWPLAYER'|array of arrays (For example, `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]`.)|None|
+|`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. Not applicable for 'IN_APP', 'IN_APP_VIDEO' and 'JWPLAYER'|array of arrays (For example, `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]`.)|None|
 |`CURRENCY_EXCHANGE`|Same as **Currency Module** in the previous Line Item Tool. When used, this option converts the _rate_ calculated from CSV to the network's currency setting. This is applicable for `WEB`, `WEB_SAFEFRAME` and `NATIVE` only. |bool|True|
 |`OPENWRAP_USE_1x1_CREATIVE`| When this option is set, the tool creates a single creative with size 1x1 and all lineitems with size overrides. |bool|False|
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ If successful, it returns all the orders in your GAM account.
     > `python -m tasks.add_new_openwrap_partner`
 3. Review your order, line items, and creatives for correctness.
 4. Finally, approve the order in GAM.
+5. To run the unit test, run:
+    > `python -m unittest -v tests.test_add_new_openwrap_partner`
 
 > **Note:** GAM may warn, "Needs creatives," on the order for ~15 minutes after order creation. This warning is usually incorrect and disappears on its own.
 

--- a/constant.py
+++ b/constant.py
@@ -13,7 +13,7 @@ VIDEO_VAST_URL = 'https://ow.pubmatic.com/cache?uuid=%%PATTERN:pwtcid%%'
 VIDEO_DURATION = 1000
 
 #video specific creative params
-SDK_VIDEO_VAST_URL = 'https://ads.pubmatic.com/openwrapsdk/assets/gam/signallingvast.xml'
+SDK_VIDEO_VAST_URL = 'https://trinity.pubmatic.com/openwrapsdk/assets/gam/signallingvast?ad_id=%%PATTERN:pwtsid_pubmatic%%'
 SDK_VIDEO_DURATION = 15000
 
 #JW Player specific creative params

--- a/constant.py
+++ b/constant.py
@@ -3,6 +3,7 @@ WEB="WEB"
 WEB_SAFEFRAME="WEB_SAFEFRAME"
 AMP="AMP"
 IN_APP="IN_APP"
+IN_APP_VIDEO="IN_APP_VIDEO"
 NATIVE="NATIVE"
 VIDEO="VIDEO"
 JW_PLAYER="JWPLAYER"
@@ -10,6 +11,10 @@ JW_PLAYER="JWPLAYER"
 #video specific creative params
 VIDEO_VAST_URL = 'https://ow.pubmatic.com/cache?uuid=%%PATTERN:pwtcid%%'
 VIDEO_DURATION = 1000
+
+#video specific creative params
+SDK_VIDEO_VAST_URL = 'https://ads.pubmatic.com/openwrapsdk/assets/gam/signallingvast.xml'
+SDK_VIDEO_DURATION = 15000
 
 #JW Player specific creative params
 JWP_VAST_URL = 'https://vpb-cache.jwplayer.com/cache?uuid=%%PATTERN:vpb_pubmatic_key%%'

--- a/dfp/associate_line_items_and_creatives.py
+++ b/dfp/associate_line_items_and_creatives.py
@@ -29,7 +29,7 @@ def make_licas(line_item_ids, creative_ids, size_overrides=[], creative_type= No
   licas = []
 
   #set creativeSetId for video line items
-  if creative_type in ('JWPLAYER', 'VIDEO'):
+  if creative_type in ('JWPLAYER', 'VIDEO', 'IN_APP_VIDEO'):
     for line_item_id in line_item_ids:
       for creative_id in creative_ids:
         licas.append({

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -92,7 +92,6 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
     },
     'startDateTimeType': 'IMMEDIATELY',
     'unlimitedEndDateTime': True,
-    'childContentEligibility': 'DISALLOWED',
     'lineItemType': lineitem_type,
     'costType': 'CPM',
     'costPerUnit': {
@@ -152,7 +151,6 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
    
   if creative_type in ('IN_APP_VIDEO'):
     line_item_config['environmentType'] = 'VIDEO_PLAYER'
-    line_item_config['childContentEligibility'] = 'ALLOWED'
     line_item_config['videoMaxDuration'] = 15000
     line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
     

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -92,6 +92,7 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
     },
     'startDateTimeType': 'IMMEDIATELY',
     'unlimitedEndDateTime': True,
+    'childContentEligibility': 'DISALLOWED',
     'lineItemType': lineitem_type,
     'costType': 'CPM',
     'costPerUnit': {
@@ -144,9 +145,14 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
   if ad_unit_ids is not None:
     line_item_config['targeting']['inventoryTargeting']['targetedAdUnits'] = [{'adUnitId': id} for id in ad_unit_ids]
 
-  if creative_type in ('VIDEO', 'JWPLAYER'):
+  if creative_type in ('VIDEO', 'IN_APP_VIDEO', 'JWPLAYER'):
     line_item_config['environmentType'] = 'VIDEO_PLAYER'
     line_item_config['videoMaxDuration'] = 60000
+    line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
+   
+  if creative_type == 'IN_APP_VIDEO':
+    line_item_config['childContentEligibility'] = 'ALLOWED'
+    line_item_config['videoMaxDuration'] = 15000
     line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
     
   return line_item_config

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -145,14 +145,15 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
   if ad_unit_ids is not None:
     line_item_config['targeting']['inventoryTargeting']['targetedAdUnits'] = [{'adUnitId': id} for id in ad_unit_ids]
 
-  if creative_type in ('VIDEO', 'IN_APP_VIDEO', 'JWPLAYER'):
+  if creative_type in ('VIDEO', 'JWPLAYER'):
     line_item_config['environmentType'] = 'VIDEO_PLAYER'
     line_item_config['videoMaxDuration'] = 60000
     line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
    
-  if creative_type == 'IN_APP_VIDEO':
+  if creative_type in ('IN_APP_VIDEO'):
+    line_item_config['environmentType'] = 'VIDEO_PLAYER'
     line_item_config['childContentEligibility'] = 'ALLOWED'
     line_item_config['videoMaxDuration'] = 15000
-    line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
+    line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
     
   return line_item_config

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -144,14 +144,14 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
   if ad_unit_ids is not None:
     line_item_config['targeting']['inventoryTargeting']['targetedAdUnits'] = [{'adUnitId': id} for id in ad_unit_ids]
 
-  if creative_type in ('VIDEO', 'JWPLAYER'):
+  if creative_type in ('VIDEO', 'JWPLAYER', 'IN_APP_VIDEO'):
     line_item_config['environmentType'] = 'VIDEO_PLAYER'
-    line_item_config['videoMaxDuration'] = 60000
-    line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
-   
-  if creative_type in ('IN_APP_VIDEO'):
-    line_item_config['environmentType'] = 'VIDEO_PLAYER'
-    line_item_config['videoMaxDuration'] = 15000
-    line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
+
+    if creative_type in ('VIDEO', 'JWPLAYER'):
+      line_item_config['videoMaxDuration'] = 60000
+      line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['VIDEO_PLAYER']}
+    else:  # creative type is IN_APP_VIDEO
+      line_item_config['videoMaxDuration'] = 15000
+      line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
     
   return line_item_config

--- a/settings.py
+++ b/settings.py
@@ -84,7 +84,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 #    Valid Values: 'Connected TV', 'Desktop', 'Feature Phone', 'Set Top Box', 'Smartphone', 'Tablet'}
 #    Defaults to no device category targeting
 #    Currently supported for OpenWrap Only
-#    Not applicable for "IN_APP" and "JWPLAYER"
+#    Not applicable for "IN_APP", "IN_APP_VIDEO" and "JWPLAYER"
 #DFP_DEVICE_CATEGORIES = ['Desktop']
 
 # Optional
@@ -129,7 +129,7 @@ OPENWRAP_BUCKET_CSV = 'LineItem.csv'
 
 # Optional
 # OpenWrap: Set custom line item targeting values
-# Not applicable for "IN_APP" and "JWPLAYER"
+# Not applicable for "IN_APP", "IN_APP_VIDEO" and "JWPLAYER"
 #OPENWRAP_CUSTOM_TARGETING = [
 #    ("a", "IS", ("1", "2", "3")),
 #    ("b", "IS_NOT", ("4", "5", "6")),

--- a/settings.py
+++ b/settings.py
@@ -9,11 +9,11 @@ GOOGLEADS_YAML_FILE = os.path.join(ROOT_DIR, 'googleads.yaml')
 #########################################################################
 
 # A string describing the order
-DFP_ORDER_NAME = 'Mobile App Header Bidding' #'test_order_name'
+DFP_ORDER_NAME = 'test_order_name'
 
 # The email of the DFP user who will be the trafficker for
 # the created order
-DFP_USER_EMAIL_ADDRESS = 'test.dfp.sandbox@gmail.com' #'testuser@email.com'
+DFP_USER_EMAIL_ADDRESS = 'testuser@email.com'
 
 # The exact name of the DFP advertiser for the created order
 # Set 'PubMatic' for openwrap Line items
@@ -27,7 +27,7 @@ DFP_ADVERTISER_TYPE = "ADVERTISER"
 
 # Lineitem type. Can be either "NETWORK", "HOUSE", "PRICE_PRIORITY" or "SPONSORSHIP"
 # This option is only for openwrap
-DFP_LINEITEM_TYPE= "SPONSORSHIP"
+DFP_LINEITEM_TYPE= "PRICE_PRIORITY"
 
 # Names of placements the line items should target.
 # For Openwrap Leave empty for Run of Network (requires Network permission)
@@ -40,12 +40,12 @@ DFP_TARGETED_AD_UNIT_NAMES = []
 # Sizes of placements. These are used to set line item and creative sizes.
 DFP_PLACEMENT_SIZES = [
   {
-    'width': '320',
-    'height': '480'
+    'width': '300',
+    'height': '250'
   },
   {
-    'width': '480',
-    'height': '320'
+    'width': '728',
+    'height': '90'
   },
 ]
 
@@ -97,7 +97,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 # Optional
 # The prefix you want to add in line item's name.
 # This option is for openwrap only
-LINE_ITEM_PREFIX = 'test_ow_sdk_video_19_li'
+#LINE_ITEM_PREFIX = 'test_li'
 
 
 #########################################################################
@@ -138,7 +138,7 @@ OPENWRAP_BUCKET_CSV = 'LineItem.csv'
 # OpenWrap Creative Type
 #  One of "WEB", "WEB_SAFEFRAME", "AMP", "IN_APP", "IN_APP_VIDEO", "NATIVE", "VIDEO", "JWPLAYER"
 #  Defaults to WEB
-OPENWRAP_CREATIVE_TYPE = "IN_APP_VIDEO"
+#OPENWRAP_CREATIVE_TYPE = "WEB"
 
 # OpenWrap Use 1x1 Creative
 #  If true, will create creatives with 1x1 and size overrides

--- a/settings.py
+++ b/settings.py
@@ -9,11 +9,11 @@ GOOGLEADS_YAML_FILE = os.path.join(ROOT_DIR, 'googleads.yaml')
 #########################################################################
 
 # A string describing the order
-DFP_ORDER_NAME = 'test_order_name'
+DFP_ORDER_NAME = 'Mobile App Header Bidding' #'test_order_name'
 
 # The email of the DFP user who will be the trafficker for
 # the created order
-DFP_USER_EMAIL_ADDRESS = 'testuser@email.com'
+DFP_USER_EMAIL_ADDRESS = 'test.dfp.sandbox@gmail.com' #'testuser@email.com'
 
 # The exact name of the DFP advertiser for the created order
 # Set 'PubMatic' for openwrap Line items
@@ -27,7 +27,7 @@ DFP_ADVERTISER_TYPE = "ADVERTISER"
 
 # Lineitem type. Can be either "NETWORK", "HOUSE", "PRICE_PRIORITY" or "SPONSORSHIP"
 # This option is only for openwrap
-DFP_LINEITEM_TYPE= "PRICE_PRIORITY"
+DFP_LINEITEM_TYPE= "SPONSORSHIP"
 
 # Names of placements the line items should target.
 # For Openwrap Leave empty for Run of Network (requires Network permission)
@@ -40,12 +40,12 @@ DFP_TARGETED_AD_UNIT_NAMES = []
 # Sizes of placements. These are used to set line item and creative sizes.
 DFP_PLACEMENT_SIZES = [
   {
-    'width': '300',
-    'height': '250'
+    'width': '320',
+    'height': '480'
   },
   {
-    'width': '728',
-    'height': '90'
+    'width': '480',
+    'height': '320'
   },
 ]
 
@@ -97,7 +97,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 # Optional
 # The prefix you want to add in line item's name.
 # This option is for openwrap only
-#LINE_ITEM_PREFIX = 'test_li'
+LINE_ITEM_PREFIX = 'test_ow_sdk_video_19_li'
 
 
 #########################################################################
@@ -136,9 +136,9 @@ OPENWRAP_BUCKET_CSV = 'LineItem.csv'
 #]
 
 # OpenWrap Creative Type
-#  One of "WEB", "WEB_SAFEFRAME", "AMP", "IN_APP", "NATIVE", "VIDEO", "JWPLAYER"
+#  One of "WEB", "WEB_SAFEFRAME", "AMP", "IN_APP", "IN_APP_VIDEO", "NATIVE", "VIDEO", "JWPLAYER"
 #  Defaults to WEB
-#OPENWRAP_CREATIVE_TYPE = "WEB"
+OPENWRAP_CREATIVE_TYPE = "IN_APP_VIDEO"
 
 # OpenWrap Use 1x1 Creative
 #  If true, will create creatives with 1x1 and size overrides

--- a/settings.py
+++ b/settings.py
@@ -105,7 +105,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = True
 #########################################################################
 
 # OpenWrap: you can specify an array to target multiple bidders with one line item
-# not applicable for JWPLAYER, IN_APP
+# not applicable for JWPLAYER, IN_APP, IN_APP_VIDEO
 PREBID_BIDDER_CODE = None
 
 # Prebid line item generator only accepts a single value

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -440,19 +440,18 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
 
   #get device capabilty ids for in-APP platform
   device_capability_ids = None
-  if device_capabilities != None:
-    if creative_type is constant.IN_APP or creative_type is constant.IN_APP_VIDEO:
-        device_capability_ids = []
-        if isinstance(device_capabilities, str):
-          device_capabilities = (device_capabilities)
+  if device_capabilities != None and creative_type in (constant.IN_APP, constant.IN_APP_VIDEO):
+    device_capability_ids = []
+    if isinstance(device_capabilities, str):
+        device_capabilities = (device_capabilities)
 
-        dc_map = dfp.get_device_capabilities.get_device_capabilities()
+    dc_map = dfp.get_device_capabilities.get_device_capabilities()
 
-        for dc in device_capabilities:
-          if dc in dc_map:
-              device_capability_ids.append(dc_map[dc])
-          else:
-              raise BadSettingException("Invalid Device Capability: {} ".format(dc))
+    for dc in device_capabilities:
+        if dc in dc_map:
+            device_capability_ids.append(dc_map[dc])
+        else:
+            raise BadSettingException("Invalid Device Capability: {} ".format(dc))
 
 
   # Get (or potentially create) the advertiser.

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -79,6 +79,7 @@ creativetype_platform_map = {
     constant.WEB_SAFEFRAME: "display",
     constant.AMP: "amp",
     constant.IN_APP: "inapp",
+    constant.IN_APP_VIDEO: "inapp_video",
     constant.NATIVE: "native",
     constant.VIDEO : "video",
     constant.JW_PLAYER : "jwp"
@@ -423,7 +424,7 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
   # Get the device category IDs
   # Dont get device categories for in-app and jwplayer platform
   device_category_ids = None
-  if device_categories != None and creative_type not in (constant.IN_APP, constant.JW_PLAYER):
+  if device_categories != None and creative_type not in (constant.IN_APP, constant.IN_APP_VIDEO, constant.JW_PLAYER):
       device_category_ids = []
       if isinstance(device_categories, str):
           device_categories = (device_categories)
@@ -439,14 +440,15 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
 
   #get device capabilty ids for in-APP platform
   device_capability_ids = None
-  if device_capabilities != None and creative_type is constant.IN_APP:
-      device_capability_ids = []
-      if isinstance(device_capabilities, str):
+  if device_capabilities != None:
+    if creative_type is constant.IN_APP or creative_type is constant.IN_APP_VIDEO:
+        device_capability_ids = []
+        if isinstance(device_capabilities, str):
           device_capabilities = (device_capabilities)
 
-      dc_map = dfp.get_device_capabilities.get_device_capabilities()
+        dc_map = dfp.get_device_capabilities.get_device_capabilities()
 
-      for dc in device_capabilities:
+        for dc in device_capabilities:
           if dc in dc_map:
               device_capability_ids.append(dc_map[dc])
           else:
@@ -486,7 +488,7 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
   creative_ids = dfp.create_creatives.create_creatives(creative_configs)
 
   # if platform is video, create creative sets
-  if creative_type in (constant.VIDEO, constant.JW_PLAYER):
+  if creative_type in (constant.VIDEO, constant.IN_APP_VIDEO, constant.JW_PLAYER):
       creative_set_configs = dfp.create_creative_sets.create_creative_set_config(creative_ids, sizes, unique_id)
       creative_ids = dfp.create_creative_sets.create_creative_sets(creative_set_configs)
 
@@ -572,7 +574,7 @@ def create_line_item_configs(prices, order_id, placement_ids, bidder_code, sizes
   key_gen_obj.set_custom_targeting(custom_targeting)
 
   #do not set platform targeting for inapp,jwplayer
-  if creative_type not in (constant.IN_APP, constant.JW_PLAYER):
+  if creative_type not in (constant.IN_APP, constant.IN_APP_VIDEO, constant.JW_PLAYER):
       key_gen_obj.set_platform_targetting()
 
   if creative_type is constant.JW_PLAYER:
@@ -632,6 +634,8 @@ def get_creative_config(creative_type, bidder_str, order_name, advertiser_id, si
         creative_configs = dfp.create_creatives.create_creative_configs_for_native(advertiser_id, creative_template_ids, num_creatives, prefix)
     elif creative_type == constant.VIDEO:
         creative_configs = dfp.create_creatives.create_creative_configs_for_video(advertiser_id, sizes, prefix, constant.VIDEO_VAST_URL, constant.VIDEO_DURATION)
+    elif creative_type == constant.IN_APP_VIDEO:
+        creative_configs = dfp.create_creatives.create_creative_configs_for_video(advertiser_id, sizes, prefix, constant.SDK_VIDEO_VAST_URL, constant.SDK_VIDEO_DURATION)
     elif creative_type == constant.JW_PLAYER:
         creative_configs = dfp.create_creatives.create_creative_configs_for_video(advertiser_id, sizes, prefix, constant.JWP_VAST_URL, constant.JWP_DURATION)
     else:
@@ -653,6 +657,8 @@ def get_unique_id(creative_type):
         uid = u'AMP_{}'.format(uid)
     if creative_type is constant.IN_APP:
         uid = u'INAPP_{}'.format(uid)
+    if creative_type is constant.IN_APP_VIDEO:
+        uid = u'INAPP_VIDEO_{}'.format(uid)
     if creative_type is constant.NATIVE:
         uid = u'NATIVE_{}'.format(uid)
     if creative_type is constant.VIDEO:
@@ -821,7 +827,7 @@ def main():
   creative_type = getattr(settings, 'OPENWRAP_CREATIVE_TYPE', None)
   if creative_type is None:
     creative_type = constant.WEB
-  elif creative_type not in [constant.WEB, constant.WEB_SAFEFRAME, constant.AMP, constant.IN_APP,
+  elif creative_type not in [constant.WEB, constant.WEB_SAFEFRAME, constant.AMP, constant.IN_APP, constant.IN_APP_VIDEO,
     constant.NATIVE, constant.VIDEO, constant.JW_PLAYER]:
     raise BadSettingException('Unknown OPENWRAP_CREATIVE_TYPE: {0}'.format(creative_type))
 
@@ -869,7 +875,7 @@ def main():
        raise BadSettingException('DFP_DEVICE_CATEGORIES')
 
   device_capabilities = None
-  if creative_type is constant.IN_APP:
+  if creative_type is constant.IN_APP or creative_type is constant.IN_APP_VIDEO:
       device_capabilities = ('Mobile Apps', 'MRAID v1', 'MRAID v2')
 
   roadblock_type = getattr(settings, 'DFP_ROADBLOCK_TYPE', 'ONE_OR_MORE')
@@ -921,6 +927,11 @@ def main():
 
   if creative_type == constant.IN_APP:
       roadblock_type = 'AS_MANY_AS_POSSIBLE'
+      bidder_code = None
+      custom_targeting = None
+      device_categories = None
+  elif creative_type == constant.IN_APP_VIDEO:
+      roadblock_type = 'ONE_OR_MORE'
       bidder_code = None
       custom_targeting = None
       device_categories = None

--- a/tests/test_add_new_openwrap_partner.py
+++ b/tests/test_add_new_openwrap_partner.py
@@ -193,6 +193,29 @@ class AddNewOpenwrapPartnerTests(TestCase):
     self.assertEqual(args[17], None)
     #check custom targetting
     self.assertEqual(args[15], None)
+
+  @patch('settings.OPENWRAP_CREATIVE_TYPE', constant.IN_APP_VIDEO, create=True)
+  @patch('tasks.add_new_openwrap_partner.setup_partner')
+  @patch('tasks.add_new_openwrap_partner.load_price_csv')
+  @patch('tasks.add_new_openwrap_partner.input', return_value='y')
+  def test_openwrap_creative_type_inapp_video(self, mock_input, mock_load_price_csv,
+    mock_setup_partners, mock_dfp_client):
+    """
+    Make sure we use the default number of creatives per line item if the
+    setting does not exist.
+    """
+    tasks.add_new_openwrap_partner.main()
+    args, _ = mock_setup_partners.call_args
+    
+    self.assertEqual(args[10], constant.IN_APP_VIDEO)
+    #check roadblock type
+    self.assertEqual(args[19], 'ONE_OR_MORE')
+    #check bidder code
+    self.assertEqual(args[8], None)
+    #check device targetting
+    self.assertEqual(args[17], None)
+    #check custom targetting
+    self.assertEqual(args[15], None)
     
   @patch('settings.OPENWRAP_CREATIVE_TYPE', constant.JW_PLAYER, create=True)
   @patch('tasks.add_new_openwrap_partner.setup_partner')
@@ -428,6 +451,81 @@ class AddNewOpenwrapPartnerTests(TestCase):
     (mock_create_creatives.create_duplicate_creative_configs
       .assert_called_once_with(bidder_code[0], order, 246810,  sizes, 2, creative_file='creative_snippet_openwrap_in_app.html', prefix='INAPP_xyz', safe_frame=False))
     mock_licas.make_licas.assert_called_once_with([543210,987650], [54321,98765], creative_type=constant.IN_APP, size_overrides=[] )
+
+
+
+
+  @patch('tasks.add_new_openwrap_partner.create_line_item_configs')
+  @patch('tasks.add_new_openwrap_partner.DFPValueIdGetter')
+  @patch('tasks.add_new_openwrap_partner.get_or_create_dfp_targeting_key')
+  @patch('dfp.associate_line_items_and_creatives')
+  @patch('dfp.create_creative_sets')
+  @patch('dfp.create_creatives')
+  @patch('dfp.create_line_items')
+  @patch('tasks.add_new_openwrap_partner.get_unique_id', return_value = 'IN_APP_VIDEO_xyz')
+  @patch('dfp.create_orders')
+  @patch('dfp.get_advertisers')
+  @patch('dfp.get_device_capabilities')
+  @patch('dfp.get_placements')
+  @patch('dfp.get_users')
+  def test_setup_partner_for_in_app_video(self, mock_get_users, mock_get_placements, mock_get_device_capabilities,
+    mock_get_advertisers, mock_create_orders, mock_get_unique_id,
+    mock_create_line_items, mock_create_creatives, mock_create_creative_sets, mock_licas, mock_dfp_client,
+    mock_get_or_create_dfp_targeting_key, mock_dfp_value_id_getter, mock_create_line_item_configs):
+    """
+    It calls all expected DFP functions.
+    """
+
+    mock_get_users.get_user_id_by_email = MagicMock(return_value=14523)
+    mock_get_placements.get_placement_ids_by_name = MagicMock(
+      return_value=[1234567, 9876543])
+    mock_get_device_capabilities.get_device_capabilities = MagicMock(
+      return_value= {
+        'Mobile Apps': 5005,
+        'MRAID v1': 5001,
+        'MRAID v2': 5006,
+        'Phone calls': 5000
+      }
+    )
+    mock_get_advertisers.get_advertiser_id_by_name = MagicMock(
+      return_value=246810)
+    mock_create_orders.create_order = MagicMock(return_value=1357913)
+    mock_create_creatives.create_creatives = MagicMock(return_value = [54321,98765])
+    mock_create_creative_sets.create_creative_sets = MagicMock(return_value = [54321,98765])
+    mock_create_line_items.create_line_items = MagicMock(
+      return_value =[543210, 987650])
+
+    prices = [{
+       'start': 1,
+       'end': 2,
+       'granularity': 1,
+       'rate': 1.5
+    }]
+
+    tasks.add_new_openwrap_partner.setup_partner(user_email=email, advertiser_name=advertiser, 
+                                               advertiser_type = advertiser_type, order_name=order,
+                                               placements=placements, sizes=sizes, lineitem_type = lineitem_type,
+                                               lineitem_prefix = 'LI_123', bidder_code=bidder_code, prices=prices,
+                                               creative_type = constant.IN_APP_VIDEO, creative_template = None, num_creatives=2,
+                                               use_1x1=False, currency_code='USD', custom_targeting= None,
+                                               same_adv_exception= False, device_categories=None, device_capabilities=['Mobile Apps'], 
+                                               roadblock_type= 'ONE_OR_MORE')
+
+    mock_get_device_capabilities.get_device_capabilities.assert_called_once()
+    mock_get_users.get_user_id_by_email.assert_called_once_with(email)
+    mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
+      placements)
+    mock_get_advertisers.get_advertiser_id_by_name.assert_called_once_with(
+      advertiser, advertiser_type)
+    mock_create_orders.create_order.assert_called_once_with(order, 246810,
+      14523)
+    (mock_create_creatives.create_creative_configs_for_video
+      .assert_called_once_with(246810, sizes, 'IN_APP_VIDEO_xyz', constant.SDK_VIDEO_VAST_URL, constant.SDK_VIDEO_DURATION))
+    mock_create_creatives.create_creatives.assert_called_once()
+    mock_create_creative_sets.create_creative_set_config.assert_called_once_with([54321,98765], sizes, 'IN_APP_VIDEO_xyz' )
+    mock_create_creative_sets.create_creative_sets.assert_called_once()
+    mock_create_line_items.create_line_items.assert_called_once()
+    mock_licas.make_licas.assert_called_once_with([543210,987650], [54321,98765], creative_type=constant.IN_APP_VIDEO, size_overrides=[])
 
 
 


### PR DESCRIPTION
**Things done:**
1. Added support for creation of rewarded video line items on GAM for openwrap SDK
2. Validated the setup by using the ad units in OWSDK's test apps
3. Updated unit tests and also added a step in Readme file about running unit tests.

**Jira ticket:**
https://inside.pubmatic.com:9443/jira/browse/SD-3598