### PR TITLE
OTT-1338: Add support for video position targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If successful, it returns all the orders in your GAM account.
 |`CURRENCY_EXCHANGE`|Same as **Currency Module** in the previous Line Item Tool. When used, this option converts the _rate_ calculated from CSV to the network's currency setting. This is applicable for `WEB`, `WEB_SAFEFRAME` and `NATIVE` only. |bool|True|
 |`OPENWRAP_USE_1x1_CREATIVE`| When this option is set, the tool creates a single creative with size 1x1 and all lineitems with size overrides. |bool|False|
 |`OPENWRAP_NATIVE_CREATIVE_USER_DEFINED_VAR`| When this option is set, the tool creates a string variable for NATIVE creative type. |string|None|
+|`VIDVIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 ## Create Line Items for Prebid
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If successful, it returns all the orders in your GAM account.
 |`CURRENCY_EXCHANGE`|Same as **Currency Module** in the previous Line Item Tool. When used, this option converts the _rate_ calculated from CSV to the network's currency setting. This is applicable for `WEB`, `WEB_SAFEFRAME` and `NATIVE` only. |bool|True|
 |`OPENWRAP_USE_1x1_CREATIVE`| When this option is set, the tool creates a single creative with size 1x1 and all lineitems with size overrides. |bool|False|
 |`OPENWRAP_NATIVE_CREATIVE_USER_DEFINED_VAR`| When this option is set, the tool creates a string variable for NATIVE creative type. |string|None|
-|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
+|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 ## Create Line Items for Prebid
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If successful, it returns all the orders in your GAM account.
 |`CURRENCY_EXCHANGE`|Same as **Currency Module** in the previous Line Item Tool. When used, this option converts the _rate_ calculated from CSV to the network's currency setting. This is applicable for `WEB`, `WEB_SAFEFRAME` and `NATIVE` only. |bool|True|
 |`OPENWRAP_USE_1x1_CREATIVE`| When this option is set, the tool creates a single creative with size 1x1 and all lineitems with size overrides. |bool|False|
 |`OPENWRAP_NATIVE_CREATIVE_USER_DEFINED_VAR`| When this option is set, the tool creates a string variable for NATIVE creative type. |string|None|
-|`VIDVIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
+|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 ## Create Line Items for Prebid
 

--- a/constant.py
+++ b/constant.py
@@ -22,7 +22,6 @@ DEALID = 'DEALID'
 PREROLL = "PREROLL"
 MIDROLL = "MIDROLL"
 POSTROLL = "POSTROLL"
-ALL = "ALL"
 
 #video specific creative params
 VIDEO_VAST_URL = 'https://ow.pubmatic.com/cache?uuid=%%PATTERN:pwtcid%%'

--- a/constant.py
+++ b/constant.py
@@ -18,6 +18,11 @@ DEALIDS = "dealids"
 DEALTIER ='DEALTIER'
 DEALID = 'DEALID'
 
+# Video Position type
+PREROLL = "PREROLL"
+MIDROLL = "MIDROLL"
+POSTROLL = "POSTROLL"
+ALL = "ALL"
 
 #video specific creative params
 VIDEO_VAST_URL = 'https://ow.pubmatic.com/cache?uuid=%%PATTERN:pwtcid%%'

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -1,4 +1,5 @@
 import logging
+import constant
 from googleads import ad_manager
 
 from dfp.client import get_client
@@ -172,7 +173,7 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
       line_item_config['videoMaxDuration'] = 15000
       line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
 
-  if setup_type in ('VIDEO', 'ADPOD'):
+  if setup_type in (constant.VIDEO, constant.ADPOD):
       if video_position_type is not None:
         line_item_config['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": video_position_type}}]}
   return line_item_config

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -30,7 +30,7 @@ def create_line_items(line_items):
 def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micro_amount, sizes, key_gen_obj,
                             lineitem_type='PRICE_PRIORITY',currency_code='USD', setup_type = None, creative_template_ids = None, 
                             same_adv_exception=False, device_categories=None,
-                            device_capabilities = None,roadblock_type = 'ONE_OR_MORE', durations = None, slot=None):
+                            device_capabilities = None,roadblock_type = 'ONE_OR_MORE', durations = None, slot=None, video_position_type = None):
   """
   Creates a line item config object.
 
@@ -171,5 +171,8 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
     else:  # creative type is IN_APP_VIDEO
       line_item_config['videoMaxDuration'] = 15000
       line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
-    
+
+  if setup_type in ('Video', 'ADPOD'):
+      if video_position_type is not None:
+        line_item_config['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": video_position_type}}]}
   return line_item_config

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -172,7 +172,7 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
       line_item_config['videoMaxDuration'] = 15000
       line_item_config['targeting']['requestPlatformTargeting'] = {'targetedRequestPlatforms': ['MOBILE_APP','VIDEO_PLAYER']}
 
-  if setup_type in ('Video', 'ADPOD'):
+  if setup_type in ('VIDEO', 'ADPOD'):
       if video_position_type is not None:
         line_item_config['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": video_position_type}}]}
   return line_item_config

--- a/docs/adpod_setup.md
+++ b/docs/adpod_setup.md
@@ -32,8 +32,8 @@
 |`DFP_SAME_ADV_EXCEPTION`|Determines whether to set the "Same Advertiser Exception" on line items. |bool|`False`|
 |`DFP_DEVICE_CATEGORIES`|Sets device category targetting for a Line item. Valid values: `Connected TV`, `Desktop`, `Feature Phone`, `Set Top Box`, `Smartphone`, and `Tablet`.|string or array of strings|None|
 |`DFP_ROADBLOCK_TYPE`| Roadblock Type. Set to  `ONE_OR_MORE` or `AS_MANY_AS_POSSIBLE`.|string|None|
-|`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. <br>  Ex:  `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]` |array of arrays .)|None|
-
+|`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. <br>  Ex:  `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]` |array of arrays|None|
+|`VIDVIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 
 #### Inline Header Bidding csv 

--- a/docs/adpod_setup.md
+++ b/docs/adpod_setup.md
@@ -33,7 +33,7 @@
 |`DFP_DEVICE_CATEGORIES`|Sets device category targetting for a Line item. Valid values: `Connected TV`, `Desktop`, `Feature Phone`, `Set Top Box`, `Smartphone`, and `Tablet`.|string or array of strings|None|
 |`DFP_ROADBLOCK_TYPE`| Roadblock Type. Set to  `ONE_OR_MORE` or `AS_MANY_AS_POSSIBLE`.|string|None|
 |`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. <br>  Ex:  `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]` |array of arrays|None|
-|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
+|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`. This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 
 #### Inline Header Bidding csv 

--- a/docs/adpod_setup.md
+++ b/docs/adpod_setup.md
@@ -33,7 +33,7 @@
 |`DFP_DEVICE_CATEGORIES`|Sets device category targetting for a Line item. Valid values: `Connected TV`, `Desktop`, `Feature Phone`, `Set Top Box`, `Smartphone`, and `Tablet`.|string or array of strings|None|
 |`DFP_ROADBLOCK_TYPE`| Roadblock Type. Set to  `ONE_OR_MORE` or `AS_MANY_AS_POSSIBLE`.|string|None|
 |`OPENWRAP_CUSTOM_TARGETING`|Array of extra targeting rules per line item. <br>  Ex:  `[("a", "IS", ("1", "2", "3")), ("b", "IS_NOT", ("4", "5", "6"))]` |array of arrays|None|
-|`VIDVIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
+|`VIDEO_POSITION_TYPE`| determines which video position lineitem will target. Valid values -  `PREROLL`, `MIDROLL`, `POSTROLL`, `ALL`.This is a optional setting and is applicable for video and adpod setup. For adpod setup each slot lineitem will have same video position targeting |string|None|
 
 
 #### Inline Header Bidding csv 

--- a/settings.py
+++ b/settings.py
@@ -214,7 +214,11 @@ DEAL_CONFIG_TYPE =  None
 # Example: DEAL_CONFIG = {"pubmatic":{"price":10,"prefix":["abc"],"dealpriority":[5]}}
 DEAL_CONFIG = None
 
-
+# VIDEO_POSITION_TYPE - video position to target
+# Valid values -  "PREROLL", "MIDROLL", "POSTROLL", "ALL"
+# This is a optional setting and is applicable for video and adpod setup
+# For adpod setup each slot lineitem will have same video position targeting
+VIDEO_POSITION_TYPE = None
 
 # Optional parameter to set creative cache url for adpod setup 
 # Defaults to ow.pubmatic.com

--- a/settings.py
+++ b/settings.py
@@ -215,7 +215,7 @@ DEAL_CONFIG_TYPE =  None
 DEAL_CONFIG = None
 
 # VIDEO_POSITION_TYPE - video position to target
-# Valid values -  "PREROLL", "MIDROLL", "POSTROLL", "ALL"
+# Valid values -  "PREROLL", "MIDROLL", "POSTROLL"
 # This is a optional setting and is applicable for video and adpod setup
 # For adpod setup each slot lineitem will have same video position targeting
 VIDEO_POSITION_TYPE = None

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -1326,7 +1326,7 @@ def main():
   video_position_type = None
   if setup_type in (constant.ADPOD, constant.VIDEO):
       video_position_type =  getattr(settings, 'VIDEO_POSITION_TYPE', None) 
-      if video_position_type is not None and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
+      if video_position_type is not None and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL) :
         raise  BadSettingException('VIDEO_POSITION_TYPE should have one of these values: {preroll}, {midroll}, {postroll} or {all}'.format(preroll =constant.PREROLL, midroll = constant.MIDROLL, postroll = constant.POSTROLL, all = constant.ALL))
 
   custom_targeting = getattr(settings, 'OPENWRAP_CUSTOM_TARGETING', None)

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -1324,9 +1324,8 @@ def main():
       raise BadSettingException('OPENWRAP_USE_1x1_CREATIVE')
 
   video_position_type =  getattr(settings, 'VIDEO_POSITION_TYPE', None) 
-  if video_position_type is not None  and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
+  if video_position_type is not None and setup_type in (constant.ADPOD, constant.VIDEO) and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
      raise  BadSettingException('VIDEO_POSITION_TYPE should have one of these values: {preroll}, {midroll}, {postroll} or {all}'.format(preroll =constant.PREROLL, midroll = constant.MIDROLL, postroll = constant.POSTROLL, all = constant.ALL))
-
 
   custom_targeting = getattr(settings, 'OPENWRAP_CUSTOM_TARGETING', None)
   if custom_targeting != None:

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -1322,10 +1322,12 @@ def main():
   use_1x1 = getattr(settings, 'OPENWRAP_USE_1x1_CREATIVE', False)
   if not isinstance(use_1x1, bool):
       raise BadSettingException('OPENWRAP_USE_1x1_CREATIVE')
-
-  video_position_type =  getattr(settings, 'VIDEO_POSITION_TYPE', None) 
-  if video_position_type is not None and setup_type in (constant.ADPOD, constant.VIDEO) and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
-     raise  BadSettingException('VIDEO_POSITION_TYPE should have one of these values: {preroll}, {midroll}, {postroll} or {all}'.format(preroll =constant.PREROLL, midroll = constant.MIDROLL, postroll = constant.POSTROLL, all = constant.ALL))
+  
+  video_position_type = None
+  if setup_type in (constant.ADPOD, constant.VIDEO):
+      video_position_type =  getattr(settings, 'VIDEO_POSITION_TYPE', None) 
+      if video_position_type is not None and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
+        raise  BadSettingException('VIDEO_POSITION_TYPE should have one of these values: {preroll}, {midroll}, {postroll} or {all}'.format(preroll =constant.PREROLL, midroll = constant.MIDROLL, postroll = constant.POSTROLL, all = constant.ALL))
 
   custom_targeting = getattr(settings, 'OPENWRAP_CUSTOM_TARGETING', None)
   if custom_targeting != None:

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -508,7 +508,7 @@ class OpenWrapTargetingKeyGen(TargetingKeyGen):
 
 def setup_partner(user_email, advertiser_name, advertiser_type, order_name, placements,
      sizes, lineitem_type, lineitem_prefix, bidder_code, prices, setup_type, creative_template, num_creatives, use_1x1,
-     currency_code, custom_targeting, same_adv_exception, device_categories, device_capabilities, roadblock_type, slot , adpod_creative_durations, creative_user_def_var, deal_config, deal_lineitem_enabled, deal_config_type):
+     currency_code, custom_targeting, same_adv_exception, device_categories, device_capabilities, roadblock_type, slot , adpod_creative_durations, creative_user_def_var, deal_config, deal_lineitem_enabled, deal_config_type, video_position_type):
   """
   Call all necessary DFP tasks for a new Prebid partner setup.
   """
@@ -641,13 +641,13 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
       line_items_config = create_deal_line_item_configs(deal_config, order_id,
       placement_ids, bidder_code, sizes, OpenWrapTargetingKeyGen(), lineitem_type, lineitem_prefix,
       currency_code, custom_targeting, setup_type, deal_config_type, ad_unit_ids=ad_unit_ids, same_adv_exception=same_adv_exception,
-      device_category_ids=None, device_capability_ids=None, roadblock_type=roadblock_type,durations=adpod_creative_durations,slot=slot)
+      device_category_ids=None, device_capability_ids=None, roadblock_type=roadblock_type,durations=adpod_creative_durations,slot=slot, video_position_type=video_position_type)
        
   else:    
       line_items_config = create_line_item_configs(prices, order_id,
       placement_ids, bidder_code, sizes, OpenWrapTargetingKeyGen(), lineitem_type, lineitem_prefix,
       currency_code, custom_targeting, setup_type, creative_template_ids, same_adv_exception=same_adv_exception,ad_unit_ids=ad_unit_ids,
-      device_category_ids=device_category_ids, device_capability_ids=device_capability_ids, roadblock_type=roadblock_type,durations=adpod_creative_durations,slot=slot)
+      device_category_ids=device_category_ids, device_capability_ids=device_capability_ids, roadblock_type=roadblock_type,durations=adpod_creative_durations,slot=slot, video_position_type = video_position_type)
   
   line_item_ids = dfp.create_line_items.create_line_items(line_items_config)
 
@@ -666,7 +666,7 @@ def setup_partner(user_email, advertiser_name, advertiser_type, order_name, plac
     
 
 def print_summary(order_name,advertiser_name,advertiser_type,adpod_size, adpod_creative_durations, deal_config, adpod_slots, lineitem_type,  lineitem_prefix,
-        setup_type, user_email, placements_print, sizes, custom_targeting, same_adv_exception, bidder_code, roadblock_type, deal_config_type):
+        setup_type, user_email, placements_print, sizes, custom_targeting, same_adv_exception, bidder_code, roadblock_type, deal_config_type, video_position_type):
     
     targeting=[] 
     li_count = 0  
@@ -704,6 +704,7 @@ def print_summary(order_name,advertiser_name,advertiser_type,adpod_size, adpod_c
       {name_start_format}Deal Config{format_end}: {value_start_format}{deal_config}{format_end}            
       
       Line items will have targeting:
+      {name_start_format}Video Position Type{format_end} = {value_start_format}{video_position_type}{format_end}
       {name_start_format}Targeting{format_end} = {value_start_format}{targeting}{format_end}
       {name_start_format}Bidders{format_end} = {value_start_format}{bidder_code}{format_end}
       {name_start_format}Placements{format_end} = {value_start_format}{placements}{format_end}
@@ -728,6 +729,7 @@ def print_summary(order_name,advertiser_name,advertiser_type,adpod_size, adpod_c
         creatives_total= adpod_size * len(adpod_creative_durations),
         deal_config = deal_config,
         deal_config_type = deal_config_type,
+        video_position_type = video_position_type,
         targeting = targeting,
         bidder_code = bidder_code,
         placements=placements_print,
@@ -756,7 +758,7 @@ def get_creative_file(setup_type):
 
 def create_deal_line_item_configs(deal_config, order_id, placement_ids, bidder_code, sizes, key_gen_obj,
   lineitem_type, lineitem_prefix, currency_code, custom_targeting, setup_type, deal_config_type, ad_unit_ids=None, same_adv_exception=False, 
-  device_category_ids=None,device_capability_ids=None, roadblock_type='ONE_OR_MORE', durations = None, slot = None):
+  device_category_ids=None,device_capability_ids=None, roadblock_type='ONE_OR_MORE', durations = None, slot = None,  video_position_type = None):
   """
   Create a line item config for each dealtier.
 
@@ -827,7 +829,8 @@ def create_deal_line_item_configs(deal_config, order_id, placement_ids, bidder_c
               device_capabilities=device_capability_ids,
               roadblock_type=roadblock_type,
               durations=durations,
-              slot=slot
+              slot=slot,
+              video_position_type=video_position_type   
             )
             line_items_config.append(config)
 
@@ -856,7 +859,8 @@ def create_deal_line_item_configs(deal_config, order_id, placement_ids, bidder_c
                   device_capabilities=device_capability_ids,
                   roadblock_type=roadblock_type,
                   durations=durations,
-                  slot=slot
+                  slot=slot,
+                  video_position_type=video_position_type
                 )
 
                 line_items_config.append(config)
@@ -867,7 +871,7 @@ def create_deal_line_item_configs(deal_config, order_id, placement_ids, bidder_c
 def create_line_item_configs(prices, order_id, placement_ids, bidder_code, sizes, key_gen_obj,
   lineitem_type, lineitem_prefix, currency_code, custom_targeting, setup_type, creative_template_ids,
   ad_unit_ids=None, same_adv_exception=False, device_category_ids=None,device_capability_ids=None,
-  roadblock_type='ONE_OR_MORE', durations = None, slot = None):
+  roadblock_type='ONE_OR_MORE', durations = None, slot = None, video_position_type = None):
   """
   Create a line item config for each price bucket.
 
@@ -967,7 +971,8 @@ def create_line_item_configs(prices, order_id, placement_ids, bidder_code, sizes
       device_capabilities=device_capability_ids,
       roadblock_type=roadblock_type,
       durations=durations,
-      slot=slot
+      slot=slot,
+      video_position_type=video_position_type
     )
 
     line_items_config.append(config)
@@ -1318,6 +1323,11 @@ def main():
   if not isinstance(use_1x1, bool):
       raise BadSettingException('OPENWRAP_USE_1x1_CREATIVE')
 
+  video_position_type =  getattr(settings, 'VIDEO_POSITION_TYPE', None) 
+  if video_position_type is not None  and video_position_type not in (constant.PREROLL, constant.MIDROLL, constant.POSTROLL, constant.ALL) :
+     raise  BadSettingException('VIDEO_POSITION_TYPE should have one of these values: {preroll}, {midroll}, {postroll} or {all}'.format(preroll =constant.PREROLL, midroll = constant.MIDROLL, postroll = constant.POSTROLL, all = constant.ALL))
+
+
   custom_targeting = getattr(settings, 'OPENWRAP_CUSTOM_TARGETING', None)
   if custom_targeting != None:
       if not isinstance(custom_targeting, (list, tuple)):
@@ -1395,6 +1405,7 @@ def main():
         {name_start_format}device categories{format_end} = {value_start_format}{device_categories}{format_end}
         {name_start_format}device capabilities{format_end} = {value_start_format}{device_capabilities}{format_end}
         {name_start_format}roadblock type{format_end} = {value_start_format}{roadblock_type}{format_end}
+        {name_start_format}video position type{format_end} = {value_start_format}{video_position_type}{format_end}
         """.format(
         num_line_items = len(prices),
         order_name=order_name,
@@ -1417,6 +1428,7 @@ def main():
         name_start_format=color.BOLD,
         format_end=color.END,
         value_start_format=color.BLUE,
+        video_position_type  = video_position_type
         ))
 
     if setup_type == constant.ADPOD:
@@ -1444,7 +1456,7 @@ def main():
   else:
     # Prininting adpod deal lineitem summary
     print_summary(order_name,advertiser_name,advertiser_type,adpod_size, adpod_creative_durations, deal_config, adpod_slots, lineitem_type,  lineitem_prefix,
-        setup_type, user_email, placements_print, sizes, custom_targeting, same_adv_exception, bidder_code, roadblock_type, deal_config_type) 
+        setup_type, user_email, placements_print, sizes, custom_targeting, same_adv_exception, bidder_code, roadblock_type, deal_config_type, video_position_type) 
         
   ok = input('Is this correct? (y/n)\n')
 
@@ -1482,7 +1494,8 @@ def main():
                     None,
                     deal_config,
                     deal_lineitem_enabled,
-                    deal_config_type
+                    deal_config_type,
+                    video_position_type
             )
 
             if deal_lineitem_enabled == False:
@@ -1516,7 +1529,8 @@ def main():
                     creative_user_def_var,
                     deal_config,
                     deal_lineitem_enabled,
-                    None
+                    None,
+                    video_position_type
             )  
     logger.info("""
 

--- a/tests/test_add_new_openwrap_partner.py
+++ b/tests/test_add_new_openwrap_partner.py
@@ -658,7 +658,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.WEB, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=['Desktop'], device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE',slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled=False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE',slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled=False, deal_config_type = None, video_position_type= None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -720,7 +720,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.VIDEO, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None, video_position_type=None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -783,7 +783,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.ADPOD, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None, video_position_type=None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -857,7 +857,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.ADPOD, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=deal_config, deal_lineitem_enabled=True, deal_config_type = "DEALTIER")
+                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=deal_config, deal_lineitem_enabled=True, deal_config_type = "DEALTIER", video_position_type=None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -929,7 +929,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.ADPOD, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=deal_config, deal_lineitem_enabled=True, deal_config_type = "DEALID")
+                                               roadblock_type= 'ONE_OR_MORE',  slot = 's1',adpod_creative_durations=[5,10], creative_user_def_var = None, deal_config=deal_config, deal_lineitem_enabled=True, deal_config_type = "DEALID", video_position_type=None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -991,7 +991,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.IN_APP, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=[], 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None, video_position_type=None)
 
     (mock_create_creatives.create_duplicate_creative_configs
       .assert_called_once_with(bidder_code[0], order, 246810,  sizes, 2, creative_file='creative_snippet_openwrap_in_app.html', prefix='INAPP_xyz', safe_frame=False))
@@ -1046,7 +1046,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.IN_APP_VIDEO, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=[], 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None, video_position_type= None)
 
     mock_get_users.get_user_id_by_email.assert_called_once_with(email)
     mock_get_placements.get_placement_ids_by_name.assert_called_once_with(
@@ -1109,7 +1109,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.IN_APP_NATIVE, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = 'pubmatic-ow-signal:%%PATTERN:pwtsid%%', deal_config=None, deal_lineitem_enabled= False,  deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = 'pubmatic-ow-signal:%%PATTERN:pwtsid%%', deal_config=None, deal_lineitem_enabled= False,  deal_config_type = None, video_position_type= None)
 
     mock_get_creative_template.get_creative_template_ids_by_name.assert_called_once()
     mock_create_creatives.create_creative_configs_for_native.assert_called_once_with(246810,  [123, 456], 2, 'IN_APP_NATIVE_xyz', 'pubmatic-ow-signal:%%PATTERN:pwtsid%%')
@@ -1163,7 +1163,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.NATIVE, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False, deal_config_type = None, video_position_type= None)
 
     mock_get_creative_template.get_creative_template_ids_by_name.assert_called_once()
     mock_create_creatives.create_creative_configs_for_native.assert_called_once_with(246810,  [123, 456], 2, 'NATIVE_xyz', None)
@@ -1209,7 +1209,7 @@ class AddNewOpenwrapPartnerTests(TestCase):
                                                setup_type = constant.NATIVE, creative_template = None, num_creatives=2,
                                                use_1x1=False, currency_code='USD', custom_targeting= None,
                                                same_adv_exception= False, device_categories=None, device_capabilities=None, 
-                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False,  deal_config_type = None)
+                                               roadblock_type= 'ONE_OR_MORE', slot = None,adpod_creative_durations=None, creative_user_def_var = None, deal_config=None, deal_lineitem_enabled= False,  deal_config_type = None, video_position_type=None)
     
     mock_get_root_ad_unit_id.get_root_ad_unit_id.assert_called_once()
     #args, kwargs = mock_create_line_item_configs.call_args

--- a/tests/test_dfp_create_line_items.py
+++ b/tests/test_dfp_create_line_items.py
@@ -49,15 +49,18 @@ class DFPCreateLineItemsTests(TestCase):
                                                     ad_unit_ids=['ad-unit', 'anoher-ad-unit'], cpm_micro_amount=24000000, sizes=[{
           'width': '728',
           'height': '90',
-        }],key_gen_obj=key_gen_obj),
+        }],key_gen_obj=key_gen_obj, video_position_type="PREROLL", setup_type='VIDEO'),
       {
         'orderId': 1234567,
         'startDateTimeType': 'IMMEDIATELY',
+        'environmentType': 'VIDEO_PLAYER',
         'targeting': {
           'inventoryTargeting': {
             'targetedAdUnits': [{'adUnitId': 'ad-unit'}, {'adUnitId': 'anoher-ad-unit'}],
             'targetedPlacementIds': ['one-placement', 'another-placement-id']
           },
+          'requestPlatformTargeting': {'targetedRequestPlatforms': ['VIDEO_PLAYER']},
+          'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'PREROLL'}}]},
           'customTargeting': {
             'children': [
               {
@@ -86,6 +89,7 @@ class DFPCreateLineItemsTests(TestCase):
         'disableSameAdvertiserCompetitiveExclusion': False,
         'lineItemType': 'PRICE_PRIORITY',
         'unlimitedEndDateTime': True,
+        'videoMaxDuration':60000,
         'primaryGoal': {
           'goalType': 'NONE'
         },


### PR DESCRIPTION
1. New VIDEO_POSITION_TYPE parameter in settings.py
2. Supported values for  **VIDEO_POSITION_TYPE:**  _PREROLL_, _MIDROLL_, _POSTROLL_, _ALL_
3. This parameter is supported for video and adpod setup
4. Optional parameter

<img width="1045" alt="Screenshot 2023-10-18 at 12 09 42 PM" src="https://github.com/PubMatic-OpenWrap/dfp-prebid-setup/assets/83747371/fe4c41b3-a225-45f0-ab8f-425b1dfa0395">
