### PR TITLE
OTT-1356: add support to update "video position" targeting of line item

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ In most cases, you won't need to change these settings.
 |`DFP_CURRENCY_CODE`|National currency to use in line items.|string|`'USD'`|
 |`DFP_LINE_ITEM_FORMAT`|The format for the line item names.|string|`u'{bidder_code}: HB ${price}'`|
 
-## [update line item setup][update]
+## Update line item setup
+<a name="update-line-item-setup"></a>
 ***[Refer this link to update line item setup](docs/update.md)***
 
 ## Limitations
 
-*   If you need to make any change to an order other than specified in [update-line-item-setup](##update), it's easiest to archive the existing order and recreate it. You can add new line items in the existing order using the setting DFP_USE_EXISTING_ORDER_IF_EXISTS. See [Extra Settings](#extra) above.
+*   If you need to make any change to an order other than specified in [update-line-item-setup](#update-line-item-setup), it's easiest to archive the existing order and recreate it. You can add new line items in the existing order using the setting DFP_USE_EXISTING_ORDER_IF_EXISTS. See [Extra Settings](#extra) above.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If successful, it returns all the orders in your GAM account.
 
 
 ## ADPOD Line Items Setup
-   ***[Refer this link for Adpod setup](docs/adpod_setup.md)*** 
+   ***[Refer this link for Adpod setup](docs/adpod_setup.md)***
 
 ## Create Line Items for OpenWrap
 
@@ -167,6 +167,9 @@ In most cases, you won't need to change these settings.
 |`DFP_CURRENCY_CODE`|National currency to use in line items.|string|`'USD'`|
 |`DFP_LINE_ITEM_FORMAT`|The format for the line item names.|string|`u'{bidder_code}: HB ${price}'`|
 
+## [update line item setup][update]
+***[Refer this link to update line item setup](docs/update.md)***
+
 ## Limitations
 
-*   Line Item Tool does not change existing orders or line items, it only creates them. If you need to make a change to an order, it's easiest to archive the existing order and recreate it. But you can add new line items in the existing order using the setting DFP_USE_EXISTING_ORDER_IF_EXISTS. See [Extra Settings](#extra) above.
+*   If you need to make any change to an order other than specified in [update-line-item-setup](##update), it's easiest to archive the existing order and recreate it. You can add new line items in the existing order using the setting DFP_USE_EXISTING_ORDER_IF_EXISTS. See [Extra Settings](#extra) above.

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,10 +1,10 @@
-# Script to update the line items
+# Update line item setup
 
 
 ## Overview
 
 
-The **tasks/update.py** utility script is designed to automate the process of modifying settings in Google Ad Manager.
+The **tasks/update.py** utility script is designed to automate the process of modifying settings in Google Ad Manager. <br>
 This script takes the user inputs from the **update_settings.py** which is orgnized as per specific task, making it easier to manage and execute updates.
 
 #### Note
@@ -12,23 +12,25 @@ This script is designed specifically for modifying line items that have been cre
 
 
 ## configuration settings - update_settings.py
-update_settings.py should be present in the root directory of project.
+`update_settings.py` should be present in the root directory of project. <br>
 It contains configuration settings of following tasks.
-1.  [Video Position](##Video Position)
+<details>
+  <summary>1. Video Position</summary><br/>
 
-## Video Position
-The `VideoPosition` class in the `update_settings.py` file contains configuration settings required to update Video Position targeting of line items.
+The `VideoPosition` class in the `update_settings.py` file contains configuration parameters that are required to update the Video Position targeting of line items.
 
 **Parameters:**
 
-| Parameter                 | Description                                                                                       | Type |  Example Value                   |
-|---------------------------|---------------------------------------------------------------------------------------------------|---------------------------------|
-| DFP_ORDER_NAME            | The name of your GAM order. Line items will be updated from this order.                    |string|    'test_order'      |
-| LINE_ITEM_NAME_REGEX      |A string representing a regular expression pattern to match line item names. <br> 1. To select all line items from order, set this to '%'  <br> 2. To select line items having prefix as 'prefix\_',  set this to 'prefix\_%'  <br>3.  To select line items having suffix as '\_suffix',  set this to '%\_suffix'| string| '%'
-| DFP_LINEITEM_TYPE         | Line item type. Can be "NETWORK", "HOUSE", "PRICE_PRIORITY", or "SPONSORSHIP".      | string               | 'PRICE_PRIORITY'                |
-| NEW_VIDEO_POSITION        | The value of new video position to target. Valid values: "PREROLL", "MIDROLL", "POSTROLL".              | string        | 'MIDROLL'                       |
 
-** How to Run:**
+|**Parameter**|**Description**|**Type**|**Example** |
+|:----------|:--------------|:-------|:---------------|
+|`DFP_ORDER_NAME`| The name of your GAM order. Line items will be updated from this order. | string |'test_order' |
+| `LINE_ITEM_NAME_REGEX`      |A string representing a regular expression pattern to match line item names. <br/> 1. To select all line items from order, set this to '%'  <br/> 2. To select line items having prefix as 'prefix\_',  set this to 'prefix\_%'  <br/>3.  To select line items having suffix as '\_suffix',  set this to '%\_suffix'| string| '%' |
+| `DFP_LINEITEM_TYPE`         | Line item type. <br>Can be "NETWORK", "HOUSE", "PRICE_PRIORITY", or "SPONSORSHIP".      | string               | 'PRICE_PRIORITY'                |
+| `NEW_VIDEO_POSITION`        | The value of new video position to target.<br>Valid values: "PREROLL", "MIDROLL", "POSTROLL".              | string        | 'MIDROLL'                       |
+
+
+**How to Run:**
 
 To execute the Video Position Update Task, use the following command:
 
@@ -41,3 +43,5 @@ python -m tasks.update VideoPosition
 2. If the selected line item has multiple video-position targeted then it will not update the line item.
 3. If the selected line item is already targeted for 'NEW_VIDEO_POSITION' then it will not update the line item.
 4. Line item to be updated should have been created using tasks/add_new_openwrap_partner.py
+
+</details>

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,43 @@
+# Script to update the line items
+
+
+## Overview
+
+
+The **tasks/update.py** utility script is designed to automate the process of modifying settings in Google Ad Manager.
+This script takes the user inputs from the **update_settings.py** which is orgnized as per specific task, making it easier to manage and execute updates.
+
+#### Note
+This script is designed specifically for modifying line items that have been created using our **tasks/add_new_openwrap_partner.py** script.
+
+
+## configuration settings - update_settings.py
+update_settings.py should be present in the root directory of project.
+It contains configuration settings of following tasks.
+1.  [Video Position](##Video Position)
+
+## Video Position
+The `VideoPosition` class in the `update_settings.py` file contains configuration settings required to update Video Position targeting of line items.
+
+**Parameters:**
+
+| Parameter                 | Description                                                                                       | Type |  Example Value                   |
+|---------------------------|---------------------------------------------------------------------------------------------------|---------------------------------|
+| DFP_ORDER_NAME            | The name of your GAM order. Line items will be updated from this order.                    |string|    'test_order'      |
+| LINE_ITEM_NAME_REGEX      |A string representing a regular expression pattern to match line item names. <br> 1. To select all line items from order, set this to '%'  <br> 2. To select line items having prefix as 'prefix\_',  set this to 'prefix\_%'  <br>3.  To select line items having suffix as '\_suffix',  set this to '%\_suffix'| string| '%'
+| DFP_LINEITEM_TYPE         | Line item type. Can be "NETWORK", "HOUSE", "PRICE_PRIORITY", or "SPONSORSHIP".      | string               | 'PRICE_PRIORITY'                |
+| NEW_VIDEO_POSITION        | The value of new video position to target. Valid values: "PREROLL", "MIDROLL", "POSTROLL".              | string        | 'MIDROLL'                       |
+
+** How to Run:**
+
+To execute the Video Position Update Task, use the following command:
+
+```
+python -m tasks.update VideoPosition
+```
+
+**Limitations**
+1. Line item to be updated should be of type "Video" because only "video" line item supports video position targeting.
+2. If the selected line item has multiple video-position targeted then it will not update the line item.
+3. If the selected line item is already targeted for 'NEW_VIDEO_POSITION' then it will not update the line item.
+4. Line item to be updated should have been created using tasks/add_new_openwrap_partner.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mock==3.0.5
 pycryptodome==3.13.0
 PyYAML==6.0.1
 shortuuid==0.5.0
+PrettyTable==3.9.0

--- a/tasks/update.py
+++ b/tasks/update.py
@@ -1,0 +1,197 @@
+
+
+import argparse
+from googleads import ad_manager
+from colorama import init
+import os
+import logging
+import sys
+import update_settings 
+
+# Colorama for cross-platform support for colored logging.
+# https://github.com/kmjennison/dfp-prebid-setup/issues/9
+init()
+
+# Configure logging.
+if 'DISABLE_LOGGING' in os.environ and os.environ['DISABLE_LOGGING'] == 'true':
+  logging.disable(logging.CRITICAL)
+  logging.getLogger('googleads').setLevel(logging.CRITICAL)
+  logging.getLogger('oauth2client').setLevel(logging.CRITICAL)
+else:
+  FORMAT = '%(message)s'
+  logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
+  logging.getLogger('googleads').setLevel(logging.ERROR)
+  logging.getLogger('oauth2client').setLevel(logging.ERROR)
+  logging.getLogger(__name__).setLevel(logging.DEBUG)
+
+def build_statement(order_name, line_item_name_regex, line_item_type):
+    # Create a statement to select line items by name and order name using regex
+    statement = (ad_manager.StatementBuilder()
+                 .Where('orderName = :order_name AND name LIKE :line_item_name AND lineItemType = :line_item_type')
+                 .WithBindVariable('order_name', order_name)
+                 .WithBindVariable('line_item_name', line_item_name_regex)
+                 .WithBindVariable('line_item_type', line_item_type))
+                 
+    return statement
+
+
+def update_line_items(ad_manager_client, response, new_position_type):
+
+    
+        line_items = response['results'] if 'results' in response else []
+
+        if line_items:
+            skip_line_items = {}
+            updated_line_items = []
+            for line_item in line_items:
+                
+                # do not update line-item if targeting information is missing
+                if 'targeting' not in line_item or not line_item['targeting']:
+                    print(f"Warning: targeting information is missing hence will not update Line Item: {line_item['name']}")
+                    skip_line_items[line_item['name']] = "targeting information is missing"
+                    continue
+
+                # do not update line-item if targeting.requestPlatformTargeting information is missing
+                if 'requestPlatformTargeting' not in line_item['targeting'] or not line_item['targeting']['requestPlatformTargeting']:
+                    print(f"Warning: targeting.requestPlatformTargeting information is missing hence will not update Line Item: {line_item['name']}")
+                    skip_line_items[line_item['name']] = "targeting.requestPlatformTargeting (Inventory type) information is missing"
+                    continue
+
+                # if targeting.videoPositionTargeting is missing then create empty object
+                if 'videoPositionTargeting' not in line_item['targeting'] or not line_item['targeting']['videoPositionTargeting']:
+                    line_item['targeting']['videoPositionTargeting'] = {}
+                
+                # if targeting.videoPositionTargeting.targetedPositions is missing then create empty object
+                if 'targetedPositions' not in line_item['targeting']['videoPositionTargeting'] or not line_item['targeting']['videoPositionTargeting']['targetedPositions']:
+                    line_item['targeting']['videoPositionTargeting']['targetedPositions'] = {}
+
+                
+                current_position = None
+                # Flag to check if the current position is same as that of new
+                found_same_video_position = False
+                # Counter to check number of video-positions targeted for the line-item
+                targeted_positions_cnt = 0
+
+                for targeted_position in line_item['targeting']['videoPositionTargeting']['targetedPositions']:
+                    if 'videoPosition' in targeted_position and targeted_position['videoPosition']:
+                        current_position = targeted_position['videoPosition']['positionType']
+                        if current_position == new_position_type:
+                            found_same_video_position = True
+                            break
+                        targeted_position['videoPosition']['positionType'] = new_position_type
+                        targeted_positions_cnt = targeted_positions_cnt + 1
+                        
+
+                if found_same_video_position:
+                    print(f"Warning: Line Item {line_item['name']} is already targeted for {new_position_type}, will not update it.")
+                    skip_line_items[line_item['name']] = "attempt to target same video position multiple time"
+                    continue
+
+                if targeted_positions_cnt > 1:
+                    print(f"Warning: Line Item {line_item['name']} is targeted for multiple video positions, will not update it.")
+                    skip_line_items[line_item['name']] = "multiple video positions found expecting only one position to update"
+                    continue
+
+                # If the video position is not updated, create a new targeting.videoPositionTargeting
+                if targeted_positions_cnt == 0:
+                    line_item['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": new_position_type}}]}
+
+                # Create an update statement
+                # update_statement = ad_manager.StatementBuilder().Where('id = :line_item_id').WithBindVariable('line_item_id', line_item['id'])
+                # update_statements.append(update_statement)
+                # updated_line_items[line_item['name']] ={"current_position":current_position, "new_position":new_position_type}
+                updated_line_items.append(line_item)
+            
+            if len(skip_line_items) > 0:
+                print(f"Following line items will not be updated")
+                print(f"Line-Item: Reason")
+                for key,value in skip_line_items.items():
+                    print(f"{key}: {value}")
+                print("----------------------------------------------")
+            
+            # Update the line items in single API call
+            if len(updated_line_items) > 0:
+                
+                # for key,value in updated_line_items.items():
+                #     print(f"Line_Item:{key} Current_Position:{value['current_position']} New_Position:{value['new_position']}")
+                
+                
+                #print(f"Line Item Name: {line_item['name']}, Current Video Position: {current_position}, New Video Position: {new_position_type}")
+                user_confirmation = input("Do you want to proceed with the update? (yes/no): ").lower()
+                if user_confirmation != 'yes':
+                    print("Update canceled.")
+                    return
+                
+                line_item_service = ad_manager_client.GetService('LineItemService', version='v202305')  # Use the appropriate API version
+
+                # single DFP/GAM API call to update all selected line items
+                rval=line_item_service.updateLineItems(updated_line_items)
+                # rval=line_item_service.updateLineItems(update_statements)
+                print(rval)
+    
+
+def simple_update_line_items(ad_manager_client, response):
+
+        line_item_service = ad_manager_client.GetService('LineItemService', version='v202305')  # Use the appropriate API version
+
+        line_items = response['results'] if 'results' in response else []
+        updated_line_items = []
+        if line_items:
+            for line_item in response['results']:
+                if not line_item['isArchived']:
+                    line_item['deliveryRateType'] = 'AS_FAST_AS_POSSIBLE'
+                    updated_line_items.append(line_item)
+
+            # Update line items remotely.
+            line_items = line_item_service.updateLineItems(updated_line_items)
+
+            # Display results.
+            if line_items:
+                for line_item in line_items:
+                    print('Line item with id "%s", belonging to order id "%s", named '
+                        '"%s", and delivery rate "%s" was updated.'
+                        % (line_item['id'], line_item['orderId'], line_item['name'],
+                            line_item['deliveryRateType']))
+                else:
+                    print('No line items were updated.')
+        else:
+            print('No line items found to update.')
+    
+             
+   
+
+def main():
+    parser = argparse.ArgumentParser(description="Update specific settings.")
+    parser.add_argument("setting_class", choices=["VideoPosition", "UpdatePrice"], help="Specify which settings to use.")
+    args = parser.parse_args()
+
+    # Set up your credentials and network code
+    ad_manager_client = ad_manager.AdManagerClient.LoadFromStorage('/home/test/go/src/Ashish/dfp-prebid-setup/googleads.yaml')
+
+    # Use settings based on the provided command-line argument
+    if args.setting_class == "VideoPosition":
+        settings_class = update_settings.VideoPosition
+    elif args.setting_class == "UpdatePrice":
+        settings_class = update_settings.UpdatePrice
+    else:
+        print("Invalid setting class.")
+        return
+
+    # Use settings from the specified class
+    order_name = settings_class.DFP_ORDER_NAME
+    line_item_name_regex = settings_class.LINE_ITEM_NAME_REGEX
+    line_item_type = settings_class.DFP_LINEITEM_TYPE
+    new_position_type = settings_class.NEW_VIDEO_POSITION
+
+    # Build the statement
+    statement = build_statement(order_name, line_item_name_regex, line_item_type)
+
+    # Get the line items
+    response = ad_manager_client.GetService('LineItemService', version='v202305').getLineItemsByStatement(statement.ToStatement())
+
+    # Update line items and list before/after with user confirmation
+    update_line_items(ad_manager_client, response, new_position_type)
+    # simple_update_line_items(ad_manager_client,response)
+
+if __name__ == "__main__":
+    main()

--- a/tasks/update.py
+++ b/tasks/update.py
@@ -1,5 +1,3 @@
-
-
 from googleads import ad_manager
 from colorama import init
 import os
@@ -73,7 +71,7 @@ class BaseSettingUpdater:
 
 class VideoPositionUpdater(BaseSettingUpdater):
     """
-    Class for updating "Video Position" of line items.
+    Class for updating "Video Position Targeting" of line items.
     """
     def confirm_inputs(self):
         """
@@ -82,10 +80,10 @@ class VideoPositionUpdater(BaseSettingUpdater):
         formatted_text = """
 Confirm the Input:
 
-{name_start_format:<}Order{format_end}: {value_start_format}{order_name:<}{format_end}
-{name_start_format:<}LineItem Name Regex{format_end}: {value_start_format}{lineitem_regex:<}{format_end}
-{name_start_format:<}LineItem Type{format_end}: {value_start_format}{lineitem_type:<}{format_end}
-{name_start_format:<}New Video Position{format_end}: {value_start_format}{new_video_position:<}{format_end}
+{name_start_format}Order{format_end}: {value_start_format}{order_name}{format_end}
+{name_start_format}LineItem Name Regex{format_end}: {value_start_format}{lineitem_regex}{format_end}
+{name_start_format}LineItem Type{format_end}: {value_start_format}{lineitem_type}{format_end}
+{name_start_format}New Video Position{format_end}: {value_start_format}{new_video_position}{format_end}
         """
 
         self.logger.info(formatted_text.format(
@@ -162,8 +160,6 @@ Confirm the Input:
             ])
         self.logger.info(table)
 
-
-
     def select_line_items_to_update(self,line_items):
         """
         Selects line items to update based on specified criteria.
@@ -182,16 +178,6 @@ Confirm the Input:
         skip_line_items = {}
 
         for line_item in line_items:
-            # do not update line-item if targeting information is missing
-            if 'targeting' not in line_item or not line_item['targeting']:
-                skip_line_items[line_item['name']] = "targeting information is missing"
-                continue
-
-            # do not update line-item if targeting.requestPlatformTargeting (Inventory type) information is missing
-            if 'requestPlatformTargeting' not in line_item['targeting'] or not line_item['targeting']['requestPlatformTargeting']:
-                skip_line_items[line_item['name']] = "targeting.requestPlatformTargeting (Inventory type) information is missing"
-                continue
-
             # if targeting.videoPositionTargeting is missing then create empty object
             if 'videoPositionTargeting' not in line_item['targeting'] or not line_item['targeting']['videoPositionTargeting']:
                 line_item['targeting']['videoPositionTargeting'] = {}
@@ -265,17 +251,17 @@ Confirm the Input:
 
 def main():
     try:
-        logger = logging.getLogger(__name__)
         if len(sys.argv) != 2:
-            logger.info("Usage: python -m task.update [VideoPosition|UpdatePrice]")
-            logger.info("Example: python -m task.update VideoPosition")
+            print("Usage: python -m tasks.update [VideoPosition]")
+            print("Example: python -m tasks.update VideoPosition")
             return
 
-        update_task = sys.argv[1]
+        update_task = sys.argv[1].lower()
+        logger = logging.getLogger(__name__)
         color = Color()
 
         # Use settings based on the command-line argument
-        if update_task == "VideoPosition":
+        if update_task == "videoposition":
             updater = VideoPositionUpdater(logger,color, get_client(), update_settings.VideoPosition)
         else:
             print("Invalid setting class.")

--- a/tasks/update.py
+++ b/tasks/update.py
@@ -1,12 +1,13 @@
 
 
-import argparse
 from googleads import ad_manager
 from colorama import init
 import os
 import logging
 import sys
-import update_settings 
+import update_settings
+from dfp.client import get_client
+from prettytable import PrettyTable
 
 # Colorama for cross-platform support for colored logging.
 # https://github.com/kmjennison/dfp-prebid-setup/issues/9
@@ -24,174 +25,268 @@ else:
   logging.getLogger('oauth2client').setLevel(logging.ERROR)
   logging.getLogger(__name__).setLevel(logging.DEBUG)
 
-def build_statement(order_name, line_item_name_regex, line_item_type):
-    # Create a statement to select line items by name and order name using regex
-    statement = (ad_manager.StatementBuilder()
+
+class Color:
+        PURPLE = '\033[95m'
+        CYAN = '\033[96m'
+        DARKCYAN = '\033[36m'
+        BLUE = '\033[94m'
+        GREEN = '\033[92m'
+        YELLOW = '\033[93m'
+        RED = '\033[91m'
+        BOLD = '\033[1m'
+        UNDERLINE = '\033[4m'
+        END = '\033[0m'
+
+class BaseSettingUpdater:
+    """
+    Base class for updating settings in the DFP/GAM system
+    """
+    def __init__(self, logger, color, ad_manager_client, setting_class):
+        """
+        Initializes a BaseSettingUpdater instance.
+
+        Parameters:
+            logger: Logger object for handling log messages.
+            color: Color object for terminal color formatting.
+            ad_manager_client: Google Ad Manager (DFP/GAM) API client.
+            setting_class: Class representing the specific settings of the task to update.
+        """
+        self.logger = logger
+        self.color=color
+        self.ad_manager_client = ad_manager_client
+        self.setting_class = setting_class
+        self.API_VERSION = "v202305"
+
+    def confirm_inputs(self):
+        """
+        Function to print and confirm the user inputs.
+        """
+        raise NotImplementedError("Subclass must implement this method")
+
+    def update(self):
+        """
+        Performs the actual update of task based on user inputs.
+        """
+        raise NotImplementedError("Subclass must implement this method")
+
+
+class VideoPositionUpdater(BaseSettingUpdater):
+    """
+    Class for updating "Video Position" of line items.
+    """
+    def confirm_inputs(self):
+        """
+        confirm_inputs prints and confirms the user inputs.
+        """
+        formatted_text = """
+Confirm the Input:
+
+{name_start_format:<}Order{format_end}: {value_start_format}{order_name:<}{format_end}
+{name_start_format:<}LineItem Name Regex{format_end}: {value_start_format}{lineitem_regex:<}{format_end}
+{name_start_format:<}LineItem Type{format_end}: {value_start_format}{lineitem_type:<}{format_end}
+{name_start_format:<}New Video Position{format_end}: {value_start_format}{new_video_position:<}{format_end}
+        """
+
+        self.logger.info(formatted_text.format(
+            order_name=self.setting_class.DFP_ORDER_NAME,
+            lineitem_regex=self.setting_class.LINE_ITEM_NAME_REGEX,
+            lineitem_type=self.setting_class.DFP_LINEITEM_TYPE,
+            new_video_position=self.setting_class.NEW_VIDEO_POSITION,
+            name_start_format=self.color.BOLD,
+            format_end=self.color.END,
+            value_start_format=self.color.BLUE,
+        ))
+
+        user_confirmation = input("Is this correct? (y/n): ").lower()
+        if user_confirmation != 'y':
+            self.logger.info('Exiting.')
+            return False
+        if self.setting_class.NEW_VIDEO_POSITION not in ("PREROLL", "MIDROLL", "POSTROLL"):
+            self.logger.info('NEW_VIDEO_POSITION supports only one of the value ("PREROLL", "MIDROLL", "POSTROLL")')
+            return False
+        return True
+
+    def get_line_items(self):
+        """
+        Function to build the statement based on filter condition and return all selected line items
+        """
+        statement = (ad_manager.StatementBuilder()
                  .Where('orderName = :order_name AND name LIKE :line_item_name AND lineItemType = :line_item_type')
-                 .WithBindVariable('order_name', order_name)
-                 .WithBindVariable('line_item_name', line_item_name_regex)
-                 .WithBindVariable('line_item_type', line_item_type))
-                 
-    return statement
+                 .WithBindVariable('order_name', self.setting_class.DFP_ORDER_NAME)
+                 .WithBindVariable('line_item_name', self.setting_class.LINE_ITEM_NAME_REGEX)
+                 .WithBindVariable('line_item_type', self.setting_class.DFP_LINEITEM_TYPE))
+
+        response = self.ad_manager_client.GetService('LineItemService', version=self.API_VERSION).getLineItemsByStatement(statement.ToStatement())
+        return response
+
+    def print_skipped_line_items(self, skip_line_items):
+        """
+        Function to print the line items that will not be updated by script along with its reason
+        """
+        if len(skip_line_items) <= 0:
+            return
+
+        table = PrettyTable()
+        self.logger.info("Following line items will not be updated:")
+        table.field_names = [
+            f"{self.color.BOLD}Line Item Name{self.color.END}",
+            f"{self.color.BOLD}Reason{self.color.END}",
+        ]
+        for line_item,reason in skip_line_items.items():
+            table.add_row([
+                f"{self.color.BLUE}{line_item}{self.color.END}",
+                f"{self.color.BLUE}{reason}{self.color.END}",
+            ])
+        self.logger.info(table)
+
+    def print_line_items_with_current_position(self, line_items_to_update):
+        """
+        Function to print the line items that will be updated by script along with current-video-position and new-video-position
+        """
+        if len(line_items_to_update) <= 0:
+            return
+
+        table = PrettyTable()
+        self.logger.info("Following line items will be updated:")
+        table.field_names = [
+            f"{self.color.BOLD}Line Item Name{self.color.END}",
+            f"{self.color.BOLD}Current Video Position{self.color.END}",
+            f"{self.color.BOLD}New Video Position{self.color.END}"
+        ]
+        for line_item,current_position in line_items_to_update.items():
+            table.add_row([
+                f"{self.color.BLUE}{line_item}{self.color.END}",
+                f"{self.color.BLUE}{current_position}{self.color.END}",
+                f"{self.color.BLUE}{self.setting_class.NEW_VIDEO_POSITION}{self.color.END}"
+            ])
+        self.logger.info(table)
 
 
-def update_line_items(ad_manager_client, response, new_position_type):
 
-    
-        line_items = response['results'] if 'results' in response else []
-
-        if line_items:
-            skip_line_items = {}
-            updated_line_items = []
-            for line_item in line_items:
-                
-                # do not update line-item if targeting information is missing
-                if 'targeting' not in line_item or not line_item['targeting']:
-                    print(f"Warning: targeting information is missing hence will not update Line Item: {line_item['name']}")
-                    skip_line_items[line_item['name']] = "targeting information is missing"
-                    continue
-
-                # do not update line-item if targeting.requestPlatformTargeting information is missing
-                if 'requestPlatformTargeting' not in line_item['targeting'] or not line_item['targeting']['requestPlatformTargeting']:
-                    print(f"Warning: targeting.requestPlatformTargeting information is missing hence will not update Line Item: {line_item['name']}")
-                    skip_line_items[line_item['name']] = "targeting.requestPlatformTargeting (Inventory type) information is missing"
-                    continue
-
-                # if targeting.videoPositionTargeting is missing then create empty object
-                if 'videoPositionTargeting' not in line_item['targeting'] or not line_item['targeting']['videoPositionTargeting']:
-                    line_item['targeting']['videoPositionTargeting'] = {}
-                
-                # if targeting.videoPositionTargeting.targetedPositions is missing then create empty object
-                if 'targetedPositions' not in line_item['targeting']['videoPositionTargeting'] or not line_item['targeting']['videoPositionTargeting']['targetedPositions']:
-                    line_item['targeting']['videoPositionTargeting']['targetedPositions'] = {}
-
-                
-                current_position = None
-                # Flag to check if the current position is same as that of new
-                found_same_video_position = False
-                # Counter to check number of video-positions targeted for the line-item
-                targeted_positions_cnt = 0
-
-                for targeted_position in line_item['targeting']['videoPositionTargeting']['targetedPositions']:
-                    if 'videoPosition' in targeted_position and targeted_position['videoPosition']:
-                        current_position = targeted_position['videoPosition']['positionType']
-                        if current_position == new_position_type:
-                            found_same_video_position = True
-                            break
-                        targeted_position['videoPosition']['positionType'] = new_position_type
-                        targeted_positions_cnt = targeted_positions_cnt + 1
-                        
-
-                if found_same_video_position:
-                    print(f"Warning: Line Item {line_item['name']} is already targeted for {new_position_type}, will not update it.")
-                    skip_line_items[line_item['name']] = "attempt to target same video position multiple time"
-                    continue
-
-                if targeted_positions_cnt > 1:
-                    print(f"Warning: Line Item {line_item['name']} is targeted for multiple video positions, will not update it.")
-                    skip_line_items[line_item['name']] = "multiple video positions found expecting only one position to update"
-                    continue
-
-                # If the video position is not updated, create a new targeting.videoPositionTargeting
-                if targeted_positions_cnt == 0:
-                    line_item['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": new_position_type}}]}
-
-                # Create an update statement
-                # update_statement = ad_manager.StatementBuilder().Where('id = :line_item_id').WithBindVariable('line_item_id', line_item['id'])
-                # update_statements.append(update_statement)
-                # updated_line_items[line_item['name']] ={"current_position":current_position, "new_position":new_position_type}
-                updated_line_items.append(line_item)
-            
-            if len(skip_line_items) > 0:
-                print(f"Following line items will not be updated")
-                print(f"Line-Item: Reason")
-                for key,value in skip_line_items.items():
-                    print(f"{key}: {value}")
-                print("----------------------------------------------")
-            
-            # Update the line items in single API call
-            if len(updated_line_items) > 0:
-                
-                # for key,value in updated_line_items.items():
-                #     print(f"Line_Item:{key} Current_Position:{value['current_position']} New_Position:{value['new_position']}")
-                
-                
-                #print(f"Line Item Name: {line_item['name']}, Current Video Position: {current_position}, New Video Position: {new_position_type}")
-                user_confirmation = input("Do you want to proceed with the update? (yes/no): ").lower()
-                if user_confirmation != 'yes':
-                    print("Update canceled.")
-                    return
-                
-                line_item_service = ad_manager_client.GetService('LineItemService', version='v202305')  # Use the appropriate API version
-
-                # single DFP/GAM API call to update all selected line items
-                rval=line_item_service.updateLineItems(updated_line_items)
-                # rval=line_item_service.updateLineItems(update_statements)
-                print(rval)
-    
-
-def simple_update_line_items(ad_manager_client, response):
-
-        line_item_service = ad_manager_client.GetService('LineItemService', version='v202305')  # Use the appropriate API version
-
-        line_items = response['results'] if 'results' in response else []
+    def select_line_items_to_update(self,line_items):
+        """
+        Selects line items to update based on specified criteria.
+        Parameters:
+            line_items (list): List of line items to be evaluated for updates.
+        Returns:
+                1. List of line items to be updated.
+                2. Dictionary mapping line item names to their current targeted video positions.
+                3. Dictionary containing line item names and reasons for skipping (not updating) each line item.
+        """
+        # List of line items to be updated
         updated_line_items = []
-        if line_items:
-            for line_item in response['results']:
-                if not line_item['isArchived']:
-                    line_item['deliveryRateType'] = 'AS_FAST_AS_POSSIBLE'
-                    updated_line_items.append(line_item)
+        # Dictionary mapping line item names to their current targeted video positions.
+        line_items_with_current_position = {}
+        # Dictionary containing line item names and reasons for skipping (not updating) each line item.
+        skip_line_items = {}
 
-            # Update line items remotely.
-            line_items = line_item_service.updateLineItems(updated_line_items)
+        for line_item in line_items:
+            # do not update line-item if targeting information is missing
+            if 'targeting' not in line_item or not line_item['targeting']:
+                skip_line_items[line_item['name']] = "targeting information is missing"
+                continue
 
-            # Display results.
-            if line_items:
-                for line_item in line_items:
-                    print('Line item with id "%s", belonging to order id "%s", named '
-                        '"%s", and delivery rate "%s" was updated.'
-                        % (line_item['id'], line_item['orderId'], line_item['name'],
-                            line_item['deliveryRateType']))
-                else:
-                    print('No line items were updated.')
-        else:
-            print('No line items found to update.')
-    
-             
-   
+            # do not update line-item if targeting.requestPlatformTargeting (Inventory type) information is missing
+            if 'requestPlatformTargeting' not in line_item['targeting'] or not line_item['targeting']['requestPlatformTargeting']:
+                skip_line_items[line_item['name']] = "targeting.requestPlatformTargeting (Inventory type) information is missing"
+                continue
+
+            # if targeting.videoPositionTargeting is missing then create empty object
+            if 'videoPositionTargeting' not in line_item['targeting'] or not line_item['targeting']['videoPositionTargeting']:
+                line_item['targeting']['videoPositionTargeting'] = {}
+
+            # if targeting.videoPositionTargeting.targetedPositions is missing then create empty object
+            if 'targetedPositions' not in line_item['targeting']['videoPositionTargeting'] or not line_item['targeting']['videoPositionTargeting']['targetedPositions']:
+                line_item['targeting']['videoPositionTargeting']['targetedPositions'] = {}
+
+            # current_position holds value of current targeted video positions
+            current_position = None
+            # flag to check if the current position is same as that of new
+            found_same_video_position = False
+            # counter to count total number of video-positions targeted for the line-item
+            targeted_positions_cnt = 0
+
+            for targeted_position in line_item['targeting']['videoPositionTargeting']['targetedPositions']:
+                if 'videoPosition' in targeted_position and targeted_position['videoPosition']:
+                    current_position = targeted_position['videoPosition']['positionType']
+                    if current_position == self.setting_class.NEW_VIDEO_POSITION:
+                        found_same_video_position = True
+                        break
+                    targeted_position['videoPosition']['positionType'] = self.setting_class.NEW_VIDEO_POSITION
+                    targeted_positions_cnt = targeted_positions_cnt + 1
+
+            if found_same_video_position:
+                skip_line_items[line_item['name']] = "attempt to target same video position multiple time"
+                continue
+
+            if targeted_positions_cnt > 1:
+                skip_line_items[line_item['name']] = "multiple video positions found, expecting only one position to update"
+                continue
+
+            # if the video position is not found, create a new targeting.videoPositionTargeting
+            if targeted_positions_cnt == 0:
+                line_item['targeting']['videoPositionTargeting'] = {"targetedPositions":[{"videoPosition":{"positionType": self.setting_class.NEW_VIDEO_POSITION}}]}
+
+            line_items_with_current_position[line_item['name']]=current_position
+            updated_line_items.append(line_item)
+
+        return updated_line_items, line_items_with_current_position, skip_line_items
+
+    def update(self):
+        """
+        Function to update "Video Position Targeting" of line items in GAM.
+        It retrieves line items from the response, selects line items to update, and then updates them using the LineItemService.
+        The user is prompted for confirmation before proceeding with the update.
+        If the update is successful, the names of the updated line items are logged.
+        """
+        response = self.get_line_items()
+        line_items = response['results'] if 'results' in response else []
+        if len(line_items) <= 0:
+            self.logger.info("No line item found for given input")
+            return
+
+        line_items_to_update, line_items_with_current_position, skip_line_items = self.select_line_items_to_update(line_items)
+        self.print_skipped_line_items(skip_line_items)
+        self.print_line_items_with_current_position(line_items_with_current_position)
+
+        if len(line_items_to_update) > 0:
+            user_confirmation = input("Do you want to proceed with the update? (y/n): ").lower()
+            if user_confirmation != 'y':
+                self.logger.info("Update canceled.")
+                return
+
+            line_item_service = self.ad_manager_client.GetService('LineItemService', version=self.API_VERSION)
+            returned_line_items=line_item_service.updateLineItems(line_items_to_update)
+            if len(returned_line_items) > 0:
+                self.logger.info("\nSuccessfully updated following line items")
+                for line_item in returned_line_items:
+                    self.logger.info(f"{self.color.BLUE}{line_item['name']}{self.color.END}")
 
 def main():
-    parser = argparse.ArgumentParser(description="Update specific settings.")
-    parser.add_argument("setting_class", choices=["VideoPosition", "UpdatePrice"], help="Specify which settings to use.")
-    args = parser.parse_args()
+    try:
+        logger = logging.getLogger(__name__)
+        if len(sys.argv) != 2:
+            logger.info("Usage: python -m task.update [VideoPosition|UpdatePrice]")
+            logger.info("Example: python -m task.update VideoPosition")
+            return
 
-    # Set up your credentials and network code
-    ad_manager_client = ad_manager.AdManagerClient.LoadFromStorage('/home/test/go/src/Ashish/dfp-prebid-setup/googleads.yaml')
+        update_task = sys.argv[1]
+        color = Color()
 
-    # Use settings based on the provided command-line argument
-    if args.setting_class == "VideoPosition":
-        settings_class = update_settings.VideoPosition
-    elif args.setting_class == "UpdatePrice":
-        settings_class = update_settings.UpdatePrice
-    else:
-        print("Invalid setting class.")
-        return
+        # Use settings based on the command-line argument
+        if update_task == "VideoPosition":
+            updater = VideoPositionUpdater(logger,color, get_client(), update_settings.VideoPosition)
+        else:
+            print("Invalid setting class.")
+            return
 
-    # Use settings from the specified class
-    order_name = settings_class.DFP_ORDER_NAME
-    line_item_name_regex = settings_class.LINE_ITEM_NAME_REGEX
-    line_item_type = settings_class.DFP_LINEITEM_TYPE
-    new_position_type = settings_class.NEW_VIDEO_POSITION
+        if not updater.confirm_inputs():
+            return
+        updater.update()
 
-    # Build the statement
-    statement = build_statement(order_name, line_item_name_regex, line_item_type)
-
-    # Get the line items
-    response = ad_manager_client.GetService('LineItemService', version='v202305').getLineItemsByStatement(statement.ToStatement())
-
-    # Update line items and list before/after with user confirmation
-    update_line_items(ad_manager_client, response, new_position_type)
-    # simple_update_line_items(ad_manager_client,response)
+    except Exception as e:
+        print(f"Fatal Error: {e}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,413 @@
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch, call
+from tasks.update import *
+from io import StringIO
+
+class TestBaseSettingUpdater(unittest.TestCase):
+    """
+    Unit tests for the BaseSettingUpdater class.
+    This test suite covers the functionality of the BaseSettingUpdater class,
+    """
+    def setUp(self):
+        self.logger = MagicMock()
+        self.color = MagicMock()
+        self.ad_manager_client = MagicMock()
+        self.setting_class = MagicMock()
+
+    def test_confirm_inputs_raises_not_implemented_error(self):
+        updater = BaseSettingUpdater(self.logger, self.color, self.ad_manager_client, self.setting_class)
+        with self.assertRaises(NotImplementedError):
+            updater.confirm_inputs()
+
+    def test_update_raises_not_implemented_error(self):
+        updater = BaseSettingUpdater(self.logger, self.color, self.ad_manager_client, self.setting_class)
+        with self.assertRaises(NotImplementedError):
+            updater.update()
+
+class TestVideoPositionUpdater(unittest.TestCase):
+    """
+    Unit tests for the VideoPositionUpdater class.
+    This test suite covers the functionality of the VideoPositionUpdater class,
+    ensuring that it correctly updates the "Video Position Targeting" of line items.
+    """
+    @patch('builtins.input', return_value='n')
+    def test_confirm_inputs_user_selects_n(self, _):
+        # setup and create class object
+        updater = VideoPositionUpdater(logger=MagicMock(), color=Color(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.DFP_ORDER_NAME = 'test_order'
+        updater.setting_class.LINE_ITEM_NAME_REGEX = '%'
+        updater.setting_class.DFP_LINEITEM_TYPE = 'PRICE_PRIORITY'
+        updater.setting_class.NEW_VIDEO_POSITION = 'INVALID'
+
+        result = updater.confirm_inputs()
+
+        self.assertFalse(result)
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 2
+
+    @patch('builtins.input', return_value='y')
+    def test_confirm_inputs_user_selects_y(self, _):
+        # setup and create class object
+        updater = VideoPositionUpdater(logger=MagicMock(), color=Color(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.DFP_ORDER_NAME = 'test_order'
+        updater.setting_class.LINE_ITEM_NAME_REGEX = '%'
+        updater.setting_class.DFP_LINEITEM_TYPE = 'PRICE_PRIORITY'
+        updater.setting_class.NEW_VIDEO_POSITION = 'MIDROLL'
+
+        result = updater.confirm_inputs()
+
+        self.assertTrue(result)
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 1
+
+    @patch('builtins.input', return_value='y')
+    def test_confirm_inputs_incorrect_video_position(self, _):
+        # setup and create class object
+        updater = VideoPositionUpdater(logger=MagicMock(), color=Color(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.DFP_ORDER_NAME = 'test_order'
+        updater.setting_class.LINE_ITEM_NAME_REGEX = '%'
+        updater.setting_class.DFP_LINEITEM_TYPE = 'PRICE_PRIORITY'
+        updater.setting_class.NEW_VIDEO_POSITION = 'INVALID'
+
+        result = updater.confirm_inputs()
+
+        self.assertFalse(result)
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 2
+
+    @patch('tasks.update.ad_manager.AdManagerClient')
+    @patch('tasks.update.ad_manager.StatementBuilder')
+    def test_get_line_items(self, mock_ad_manager_client, mock_statement_builder):
+        # setup and create class object
+        expected_result = {'results': [{'name': 'line_item_1'}, {'name': 'line_item_2'}]}
+        mock_line_item_service = MagicMock()
+        mock_line_item_service = mock_ad_manager_client.GetService.return_value
+        mock_line_item_service.getLineItemsByStatement.return_value = expected_result
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=mock_ad_manager_client, setting_class=MagicMock())
+
+        result = updater.get_line_items()
+        self.assertEqual(result, expected_result)
+
+    def test_print_skipped_line_items(self):
+        # setup and create class object
+        mock_logger = MagicMock()
+        updater = VideoPositionUpdater(logger=mock_logger, color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+
+        updater.print_skipped_line_items({})
+        updater.logger.info.assert_not_called()
+
+        updater.print_skipped_line_items({'line_item_1': 'reason_1', 'line_item_2': 'reason_2'})
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 2
+
+    def test_print_line_items_with_current_position(self):
+        # setup and create class object
+        mock_logger = MagicMock()
+        updater = VideoPositionUpdater(logger=mock_logger, color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+
+        updater.print_line_items_with_current_position({})
+        updater.logger.info.assert_not_called()
+
+        updater.print_line_items_with_current_position({'line_item_1': 'PREROLL', 'line_item_2': 'POSTROLL'})
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 2
+
+    def test_select_line_items_to_update_found_empty_list(self):
+        line_items = []
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(len(updated_line_items), 0)
+        self.assertEqual(len(line_items_with_current_position), 0)
+        self.assertEqual(len(skip_line_items), 0)
+
+    def test_select_line_items_to_update_when_videoPositionTargeting_is_absent(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {}
+            }
+        ]
+        expected_updated_line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            }
+        ]
+        expected_line_item_with_curr_pos = { 'line_item_1': None }
+        expected_skip_line_items = {}
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    def test_select_line_items_to_update_when_targetedPositions_is_absent(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {}}
+            }
+        ]
+        expected_updated_line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            }
+        ]
+        expected_line_item_with_curr_pos = { 'line_item_1': None }
+        expected_skip_line_items = {}
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    def test_select_line_items_to_update_when_videoPosition_is_absent(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': []}}
+            }
+        ]
+        expected_updated_line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            }
+        ]
+        expected_line_item_with_curr_pos = { 'line_item_1': None }
+        expected_skip_line_items = {}
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    def test_select_line_items_to_update_when_videoPosition_is_already_targeted(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            }
+        ]
+        expected_updated_line_items = []
+        expected_line_item_with_curr_pos = {}
+        expected_skip_line_items = {
+            'line_item_1': 'attempt to target same video position multiple time',
+        }
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    def test_select_line_items_to_update_when_multiple_videoPosition_are_targeted(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}},{'videoPosition': {'positionType': 'PREROLL'}}]}}
+            }
+        ]
+        expected_updated_line_items = []
+        expected_line_item_with_curr_pos = {}
+        expected_skip_line_items = {
+            'line_item_1': "multiple video positions found, expecting only one position to update",
+        }
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'MIDROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    def test_select_line_items_to_update_for_multiple_line_items_passed_as_input(self):
+        line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': []}}
+            },
+            {
+                'name': 'line_item_2',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'MIDROLL'}}]}}
+            },
+            {
+                'name': 'line_item_3',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            }
+        ]
+        expected_updated_line_items = [
+            {
+                'name': 'line_item_1',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            },
+            {
+                'name': 'line_item_2',
+                'targeting': {'videoPositionTargeting': {'targetedPositions': [{'videoPosition': {'positionType': 'POSTROLL'}}]}}
+            },
+        ]
+        expected_line_item_with_curr_pos = {
+            'line_item_1': None,
+            'line_item_2': "MIDROLL"
+        }
+        expected_skip_line_items = {
+            'line_item_3': "attempt to target same video position multiple time"
+        }
+
+        updater = VideoPositionUpdater(logger=MagicMock(), color=MagicMock(), ad_manager_client=MagicMock(), setting_class=MagicMock())
+        updater.setting_class.NEW_VIDEO_POSITION = 'POSTROLL'
+
+        updated_line_items, line_items_with_current_position, skip_line_items = updater.select_line_items_to_update(line_items)
+
+        self.assertEqual(updated_line_items, expected_updated_line_items)
+        self.assertEqual(line_items_with_current_position, expected_line_item_with_curr_pos)
+        self.assertEqual(skip_line_items, expected_skip_line_items)
+
+    @patch('tasks.update.ad_manager.AdManagerClient')
+    def test_update_when_no_line_items_returned_by_GAM(self, mock_ad_manager_client):
+        mock_logger = MagicMock()
+        updater = VideoPositionUpdater(logger=mock_logger, color=MagicMock(), ad_manager_client=mock_ad_manager_client, setting_class=MagicMock())
+
+        # Mock the get_line_items method to return a response with line items
+        with patch.object(updater, 'get_line_items', return_value={}):
+            updater.update()
+
+        mock_logger.info.assert_called_once_with("No line item found for given input")
+
+    @patch('tasks.update.ad_manager.AdManagerClient')
+    def test_update_when_no_line_items_found_to_update(self, mock_ad_manager_client):
+        mock_logger = MagicMock()
+        updater = VideoPositionUpdater(logger=mock_logger, color=MagicMock(), ad_manager_client=mock_ad_manager_client, setting_class=MagicMock())
+
+        # Mock the get_line_items method to return a response with line items
+        with patch.object(updater, 'get_line_items', return_value={'results': [{'name': 'line_item_1'}]}):
+            with patch.object(updater, 'select_line_items_to_update', return_value=([], {}, {})):
+                updater.update()
+
+        mock_logger.info.assert_not_called()
+        mock_ad_manager_client.GetService.assert_not_called()
+
+
+    @patch('builtins.input', return_value='n')
+    @patch('tasks.update.ad_manager.AdManagerClient')
+    def test_update_when_user_dont_want_to_proceed(self, mock_ad_manager_client,mock_input):
+        mock_logger = MagicMock()
+        updater = VideoPositionUpdater(logger=mock_logger, color=MagicMock(), ad_manager_client=mock_ad_manager_client, setting_class=MagicMock())
+
+        # Mock the get_line_items method to return a response with line items
+        with patch.object(updater, 'get_line_items', return_value={'results': [{'name': 'line_item_1'}]}):
+            with patch.object(updater, 'select_line_items_to_update', return_value=([{'name': 'line_item_1'}], {}, {})):
+                updater.update()
+
+        mock_logger.info.assert_called_once_with("Update canceled.")
+        mock_ad_manager_client.GetService.assert_not_called()
+
+    @patch('builtins.input', return_value='y')
+    @patch('tasks.update.ad_manager.AdManagerClient')
+    def test_update_after_user_confirmation(self, mock_ad_manager_client,mock_input):
+        mock_logger = MagicMock()
+        expected_result = [{'name': 'line_item_1'}]
+        mock_line_item_service = MagicMock()
+        mock_line_item_service = mock_ad_manager_client.GetService.return_value
+        mock_line_item_service.updateLineItems.return_value = expected_result
+
+        updater = VideoPositionUpdater(logger=mock_logger(), color=MagicMock(), ad_manager_client=mock_ad_manager_client, setting_class=MagicMock())
+
+        # Mock the get_line_items method to return a response with line items
+        with patch.object(updater, 'get_line_items', return_value={'results': [{'name': 'line_item_1'}]}):
+            with patch.object(updater, 'select_line_items_to_update', return_value=([{'name': 'line_item_1'}], {}, {})):
+                updater.update()
+
+        mock_ad_manager_client.GetService.assert_called()
+        updater.logger.info.assert_called()
+        assert updater.logger.info.call_count == 2
+
+class TestMainFunction(unittest.TestCase):
+    """
+    Unit tests for the main function.
+    This test suite covers the functionality of the main function.
+    """
+
+    @patch('builtins.print')
+    @patch('tasks.update.sys.argv', ['program_name'])
+    def test_main_when_command_line_arg_is_absent(self,mock_print):
+        main()
+        expected_print_calls = [
+            call("Usage: python -m tasks.update [VideoPosition]"),
+            call("Example: python -m tasks.update VideoPosition")
+        ]
+        mock_print.assert_has_calls(expected_print_calls, any_order=True)
+
+    @patch('tasks.update.VideoPositionUpdater')
+    @patch('tasks.update.sys.argv', ['program_name', "videoposition"])
+    def test_main_when_command_line_arg_is_correct(self,mock_updater):
+        main()
+
+        mock_updater.assert_called_once()
+        mock_updater.return_value.confirm_inputs.assert_called_once()
+        mock_updater.return_value.update.assert_called_once()
+
+    @patch('builtins.print')
+    @patch('tasks.update.sys.argv', ['program_name', "invalid"])
+    def test_main_when_command_line_arg_is_incorrect_choice(self,mock_print):
+        main()
+        expected_print_calls = [
+            call("Invalid setting class."),
+        ]
+        mock_print.assert_has_calls(expected_print_calls, any_order=True)
+
+    @patch('tasks.update.VideoPositionUpdater')
+    @patch('tasks.update.sys.argv', ['program_name', "videoposition"])
+    def test_main_when_confirm_inputs_returns_false(self,mock_updater):
+        mock_updater.return_value.confirm_inputs.return_value = False
+        main()
+        mock_updater.assert_called_once()
+        mock_updater.return_value.update.assert_not_called()
+
+    @patch('tasks.update.VideoPositionUpdater')
+    @patch('tasks.update.sys.argv', ['program_name', 'VideoPosition'])
+    def test_main_catch_exception(self, mock_updater):
+        # Set up the mock to raise an exception
+        mock_instance = mock_updater.return_value
+        mock_instance.confirm_inputs.side_effect = Exception("Test Exception")
+
+        # Capture the standard output
+        captured_output = StringIO()
+        sys.stdout = captured_output
+
+        try:
+            main()
+        except Exception as e:
+            self.assertEqual(str(e), "Test Exception")
+
+        # Reset the standard output
+        sys.stdout = sys.__stdout__
+
+        captured_output_str = captured_output.getvalue()
+        self.assertIn("Fatal Error: Test Exception", captured_output_str)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/update_settings.py
+++ b/update_settings.py
@@ -1,0 +1,26 @@
+# settings.py
+
+# This utility class encapsulates configuration settings for updating the video positions of line items within a designated order.
+# To execute the update, use the command: `python3 -m tasks.update VideoPosition`.
+# The task requires input parameters such as DFP_ORDER_NAME, LINE_ITEM_NAME_REGEX, and DFP_LINEITEM_TYPE, 
+# and it performs the update by setting the video position of all selected line items to the specified NEW_POSITION_TYPE.
+# Note: This update task assumes 'videoPositionTargeting' 
+class VideoPosition:
+    
+    # DFP_ORDER_NAME: A string describing the order. Line items will be updated from this order.
+    DFP_ORDER_NAME = 'ashish_test_order'
+    
+    # LINE_ITEM_NAME_REGEX: A string represents a regular expression pattern that can be used to match line item names.
+    # It supports '%' as a wildcard character, representing zero or more characters.
+    # To update all line items present in 'DFP_ORDER_NAME', set LINE_ITEM_NAME_REGEX = '%'
+    # To update line items having prefix as 'prefix_', set LINE_ITEM_NAME_REGEX = 'prefix_%'
+    # To update line items having suffix as '_suffix', set LINE_ITEM_NAME_REGEX = '%_suffix'
+    LINE_ITEM_NAME_REGEX = '%'
+    
+    # DFP_LINEITEM_TYPE: Lineitem type. Can be either "NETWORK", "HOUSE", "PRICE_PRIORITY" or "SPONSORSHIP"
+    DFP_LINEITEM_TYPE= 'PRICE_PRIORITY'
+
+    # NEW_VIDEO_POSITION: video position to target
+    # Valid values -  "PREROLL", "MIDROLL", "POSTROLL"
+    NEW_VIDEO_POSITION = 'MIDROLL'
+

--- a/update_settings.py
+++ b/update_settings.py
@@ -1,26 +1,32 @@
-# settings.py
+# update_settings.py
+
+import os
+
+# Add common setting
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+GOOGLEADS_YAML_FILE = os.path.join(ROOT_DIR, 'googleads.yaml')
+
 
 # This utility class encapsulates configuration settings for updating the video positions of line items within a designated order.
 # To execute the update, use the command: `python3 -m tasks.update VideoPosition`.
-# The task requires input parameters such as DFP_ORDER_NAME, LINE_ITEM_NAME_REGEX, and DFP_LINEITEM_TYPE, 
+# The task requires input parameters such as DFP_ORDER_NAME, LINE_ITEM_NAME_REGEX, and DFP_LINEITEM_TYPE,
 # and it performs the update by setting the video position of all selected line items to the specified NEW_POSITION_TYPE.
-# Note: This update task assumes 'videoPositionTargeting' 
 class VideoPosition:
-    
+
     # DFP_ORDER_NAME: A string describing the order. Line items will be updated from this order.
-    DFP_ORDER_NAME = 'ashish_test_order'
-    
+    DFP_ORDER_NAME = 'test_order'
+
     # LINE_ITEM_NAME_REGEX: A string represents a regular expression pattern that can be used to match line item names.
     # It supports '%' as a wildcard character, representing zero or more characters.
     # To update all line items present in 'DFP_ORDER_NAME', set LINE_ITEM_NAME_REGEX = '%'
     # To update line items having prefix as 'prefix_', set LINE_ITEM_NAME_REGEX = 'prefix_%'
     # To update line items having suffix as '_suffix', set LINE_ITEM_NAME_REGEX = '%_suffix'
     LINE_ITEM_NAME_REGEX = '%'
-    
+
     # DFP_LINEITEM_TYPE: Lineitem type. Can be either "NETWORK", "HOUSE", "PRICE_PRIORITY" or "SPONSORSHIP"
     DFP_LINEITEM_TYPE= 'PRICE_PRIORITY'
 
     # NEW_VIDEO_POSITION: video position to target
     # Valid values -  "PREROLL", "MIDROLL", "POSTROLL"
-    NEW_VIDEO_POSITION = 'MIDROLL'
+    NEW_VIDEO_POSITION = 'POSTROLL'
 


### PR DESCRIPTION
update_settings.py would be used to take the user inputs.

**Command to execute update script** 
` python3 -m  tasks.update videoposition`

**Commands to check the unit test code coverage**
```
python3 -m unittest tests.test_update
coverage run -m tests.test_update
coverage report -m
coverage html
google-chrome htmlcov/index.html 
```


Test case coverage report - 

```
Name                                                                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------------
tasks/update.py                                                                             145      5    97%   16-18, 25
```