### PR TITLE
UOE-10122: Remove order and advertiser from the LI CSV

### DIFF
--- a/Inline_Header_Bidding_Auto.csv
+++ b/Inline_Header_Bidding_Auto.csv
@@ -1,5 +1,5 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0,5,0.05,2
-PubMatic_CSAPI_test,PubMatic,5,10,0.1,2
-PubMatic_CSAPI_test,PubMatic,10,20,0.5,2
-PubMatic_CSAPI_test,PubMatic,20,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0,5,0.05,2
+5,10,0.1,2
+10,20,0.5,2
+20,999,-1,2

--- a/Inline_Header_Bidding_CTV-Med.csv
+++ b/Inline_Header_Bidding_CTV-Med.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0,100,0.50,2
-PubMatic_CSAPI_test,PubMatic,100,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0,100,0.50,2
+PubMatic,100,999,-1,2

--- a/Inline_Header_Bidding_Dense.csv
+++ b/Inline_Header_Bidding_Dense.csv
@@ -1,5 +1,5 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0.01,3,0.01,2
-PubMatic_CSAPI_test,PubMatic,3,8,0.05,2
-PubMatic_CSAPI_test,PubMatic,8,20,0.5,2
-PubMatic_CSAPI_test,PubMatic,20,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0.01,3,0.01,2
+3,8,0.05,2
+8,20,0.5,2
+20,999,-1,2

--- a/Inline_Header_Bidding_High.csv
+++ b/Inline_Header_Bidding_High.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0.01,20,0.01,2
-PubMatic_CSAPI_test,PubMatic,20,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0.01,20,0.01,2
+20,999,-1,2

--- a/Inline_Header_Bidding_Low.csv
+++ b/Inline_Header_Bidding_Low.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0,5,0.5,2
-PubMatic_CSAPI_test,PubMatic,5,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0,5,0.5,2
+5,999,-1,2

--- a/Inline_Header_Bidding_Med.csv
+++ b/Inline_Header_Bidding_Med.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,0,20,0.1,2
-PubMatic_CSAPI_test,PubMatic,20,999,-1,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+0,20,0.1,2
+20,999,-1,2

--- a/Inline_Header_Bidding_Test.csv
+++ b/Inline_Header_Bidding_Test.csv
@@ -1,2 +1,2 @@
 start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-5,15,5.0,2
+5,10,5.0,2

--- a/Inline_Header_Bidding_Test.csv
+++ b/Inline_Header_Bidding_Test.csv
@@ -1,2 +1,2 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-Shriprasad_Test_Advertiser,inlinehb_Adpod_setup_test_order,5,10,5.0,2
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+5,15,5.0,2

--- a/LineItem.csv
+++ b/LineItem.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,1,5,1,1
-PubMatic_CSAPI_test,PubMatic,5,10,-1,1
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+1,5,1,1
+5,10,-1,1

--- a/docs/adpod_setup.md
+++ b/docs/adpod_setup.md
@@ -39,7 +39,6 @@
 #### Inline Header Bidding csv 
 For Adpod setup use/edit one of the following csv files present in `dfp-prebid-setup`  folder for `OPENWRAP_BUCKET_CSV` parameter 
 
- ***Note: Ignore the Order Name and Advertiser columns are in the CSV file. Specify those settings in, settings.py ***
  ***In the line item csv files the `rate_id` value should always be `2 (minimum)` for Adpod setup***
  
 |  Price Granularity | CSV File |
@@ -63,11 +62,11 @@ For Adpod setup use/edit one of the following csv files present in `dfp-prebid-s
 2. Enter a granularity level of -1 for the final line item. This covers all targeting within the range to the endpoint. 
 (the last line with granularity “-1” covers all bids between $20-$30): 
 
-| order_name | advertiser | start_range | end_range | granularity | rate_id |
-|--|--|--|--|--| --|
-|"Pubmatic HB" | "Pubmatic" | 0 | 10 | 1 | 2 |
-|"Pubmatic HB" | "Pubmatic" | 10 | 20 | 2 | 2 
-|"Pubmatic HB" | "Pubmatic" | 20 | 30 | -1 | 2 
+| start_range | end_range | granularity | rate_id |
+|--|--|--| --|
+|0 | 10 | 1 | 2 |
+|10 | 20 | 2 | 2 |
+|20 | 30 | -1 | 2 |
 
 *****Rates (pwtpb) created with above granularity: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16 ,18, 20]***** 
 

--- a/settings.py
+++ b/settings.py
@@ -127,8 +127,6 @@ PREBID_PRICE_BUCKETS = {
 }
 
 # OpenWrap: Buckets are specified in a CSV file
-#  Same file format as the PubMatic Line Item tool
-#  Order and advertiser name from csv are ignored
 OPENWRAP_BUCKET_CSV = 'LineItem.csv'
 
 # Optional

--- a/tasks/add_new_openwrap_partner.py
+++ b/tasks/add_new_openwrap_partner.py
@@ -9,7 +9,7 @@ import sys
 import tasks
 from builtins import input
 from pprint import pprint
-
+from prettytable import PrettyTable
 from colorama import init
 
 import constant
@@ -1099,23 +1099,22 @@ def load_price_csv(filename, setup_type):
         network = get_dfp_network()
         logger.info("Network currency : %s", network.currencyCode)
         exchange_rate = get_exchange_rate(network.currencyCode)
-
     logger.info("Currency exchange rate: {}".format(exchange_rate))
     #currency rate handling till here
     with open(filename, 'r') as csvfile:
         preader = csv.reader(csvfile)
         next(preader)  # skip header row
+        pg_ranges = []
         for row in preader:
                 # ignore extra lines or spaces
                 if row == [] or row[0].strip() == "":
                     continue
-                print(row)
-
+                pg_ranges.append(row)
                 try:
-                    start_range = float(row[2])
-                    end_range = float(row[3])
-                    granularity = float(row[4])
-                    rate_id = int(row[5])
+                    start_range = float(row[0].strip())
+                    end_range = float(row[1].strip())
+                    granularity = float(row[2].strip())
+                    rate_id = int(row[3].strip())
                     if setup_type == constant.ADPOD:
                         rate_id = 2
                 except ValueError:
@@ -1145,7 +1144,22 @@ def load_price_csv(filename, setup_type):
                         'granularity': 1.0,
                         'rate': get_calculated_rate(start_range, end_range, rate_id, exchange_rate, precision)
                      })
-
+        logger.info("\nPrice Granularity Ranges:")
+        table = PrettyTable()
+        table.field_names = [
+            f"{color.BOLD}Start Range{color.END}",
+            f"{color.BOLD}End Range{color.END}",
+            f"{color.BOLD}Granularity{color.END}",
+            f"{color.BOLD}RateId{color.END}",
+        ]
+        for start, end, price_granularity, rateId in pg_ranges:
+            table.add_row([
+                f"{color.BLUE}{start.strip()}{color.END}",
+                f"{color.BLUE}{end.strip()}{color.END}",
+                f"{color.BLUE}{price_granularity.strip()}{color.END}",
+                f"{color.BLUE}{rateId.strip()}{color.END}",
+            ])
+        logger.info(table)    
     return buckets
 
 def validateCSVValues(start_range, end_range, granularity, rate_id):

--- a/test.csv
+++ b/test.csv
@@ -1,3 +1,3 @@
-order_name,advertiser,start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
-PubMatic_CSAPI_test,PubMatic,1,5,1,1
-PubMatic_CSAPI_test,PubMatic,5,10,-1,1
+start_range,end_range,granularity,"rate_id[1=Average, 2=Minimum] "
+1,5,1,1
+5,10,-1,1


### PR DESCRIPTION
1. Remove order and advertiser from the LI CSV
2. Updated doc
3. Display PG in table

<img width="470" alt="Screenshot 2024-02-16 at 1 53 41 PM" src="https://github.com/PubMatic-OpenWrap/dfp-prebid-setup/assets/83747371/5d4f0225-5d18-4e7a-bdd7-767beca49327">
